### PR TITLE
Update sample insert sql for MySQL5.6

### DIFF
--- a/Tutorial-mysql_replicator_multi.md
+++ b/Tutorial-mysql_replicator_multi.md
@@ -41,9 +41,9 @@ mysql> use replicator_manager;
 
 -- Add replicate source connection and query settings like below.
 mysql> INSERT INTO `settings`
-  (`id`, `is_active`, `name`, `host`, `port`, `username`, `password`, `database`, `query`, `interval`, `primary_key`, `enable_delete`)
+  (`id`, `is_active`, `name`, `host`, `port`, `username`, `password`, `database`, `query`, `prepared_query`, `interval`, `primary_key`, `enable_delete`)
 VALUES
-  (NULL, 1, 'mydb.mytable', '192.168.100.221', 3306, 'mysqluser', 'mysqlpassword', 'mydb', 'SELECT id, text from mytable;', 5, 'id', 1);
+  (NULL, 1, 'mydb.mytable', '192.168.100.221', 3306, 'mysqluser', 'mysqlpassword', 'mydb', 'SELECT id, text from mytable;', '', 5, 'id', 1);
 ```
 
 it is a sample which you have inserted row.


### PR DESCRIPTION
MySQL5.6 default sql_mode option has STRICT_TRANS_TABLES.
Therefore, the previous insert sql show ERROR 1364 (HY000): Field 'prepared_query' doesn't have a default value.
