### PR TITLE
Use router.emit instead of Engine.emit

### DIFF
--- a/lib/fluent/plugin/in_mysql_replicator.rb
+++ b/lib/fluent/plugin/in_mysql_replicator.rb
@@ -123,7 +123,7 @@ module Fluent
     end
 
     def emit_record(tag, record)
-      Engine.emit(tag, Engine.now, record)
+      router.emit(tag, Engine.now, record)
     end
 
     def query(query, con = nil)

--- a/lib/fluent/plugin/in_mysql_replicator.rb
+++ b/lib/fluent/plugin/in_mysql_replicator.rb
@@ -2,6 +2,11 @@ module Fluent
   class MysqlReplicatorInput < Fluent::Input
     Plugin.register_input('mysql_replicator', self)
 
+    # Define `router` method to support v0.10.57 or earlier
+    unless method_defined?(:router)
+      define_method("router") { Engine }
+    end
+
     def initialize
       require 'mysql2'
       require 'digest/sha1'

--- a/lib/fluent/plugin/in_mysql_replicator_multi.rb
+++ b/lib/fluent/plugin/in_mysql_replicator_multi.rb
@@ -239,7 +239,7 @@ module Fluent
     end
 
     def emit_record(tag, record)
-      Engine.emit(tag, Engine.now, record)
+      router.emit(tag, Engine.now, record)
     end
 
     def get_manager_connection

--- a/lib/fluent/plugin/in_mysql_replicator_multi.rb
+++ b/lib/fluent/plugin/in_mysql_replicator_multi.rb
@@ -2,6 +2,11 @@ module Fluent
   class MysqlReplicatorMultiInput < Fluent::Input
     Plugin.register_input('mysql_replicator_multi', self)
 
+    # Define `router` method to support v0.10.57 or earlier
+    unless method_defined?(:router)
+      define_method("router") { Engine }
+    end
+
     def initialize
       require 'mysql2'
       require 'digest/sha1'


### PR DESCRIPTION
Fluentd 0.10.58 or later supports router.emit API.