### PR TITLE
ssl support and basic authentication

### DIFF
--- a/example/mysql_multi_table_to_elasticsearch.md
+++ b/example/mysql_multi_table_to_elasticsearch.md
@@ -28,6 +28,13 @@ It is a guide to replicate multiple mysql table to elasticsearch.
   host localhost
   port 9200
 
+  # You can configure to use SSL for connecting to Elasticsearch.
+  # ssl true
+
+  # Basic authentication credentials can be configured
+  # username basic_auth_username
+  # password basic_auth_password
+
   # Set Elasticsearch index, type, and unique id (primary_key) from tag.
   tag_format (?<index_name>[^\.]+)\.(?<type_name>[^\.]+)\.(?<event>[^\.]+)\.(?<primary_key>[^\.]+)$
 

--- a/example/mysql_single_table_to_elasticsearch.md
+++ b/example/mysql_single_table_to_elasticsearch.md
@@ -37,6 +37,13 @@ It is a guide to replicate single mysql table to elasticsearch.
   host localhost
   port 9200
 
+  # You can configure to use SSL for connecting to Elasticsearch.
+  # ssl true
+
+  # Basic authentication credentials can be configured
+  # username basic_auth_username
+  # password basic_auth_password
+
   # Set Elasticsearch index, type, and unique id (primary_key) from tag.
   tag_format (?<core_name>[^\.]+)\.(?<event>[^\.]+)\.(?<primary_key>[^\.]+)$
 

--- a/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
+++ b/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
@@ -7,6 +7,7 @@ class Fluent::MysqlReplicatorElasticsearchOutput < Fluent::BufferedOutput
   config_param :host, :string,  :default => 'localhost'
   config_param :port, :integer, :default => 9200
   config_param :tag_format, :string, :default => nil
+  config_param :ssl, :bool, :default => false
 
   DEFAULT_TAG_FORMAT = /(?<index_name>[^\.]+)\.(?<type_name>[^\.]+)\.(?<event>[^\.]+)\.(?<primary_key>[^\.]+)$/
 
@@ -60,6 +61,8 @@ class Fluent::MysqlReplicatorElasticsearchOutput < Fluent::BufferedOutput
     bulk_message << ""
 
     http = Net::HTTP.new(@host, @port.to_i)
+    http.use_ssl = @ssl
+
     request = Net::HTTP::Post.new('/_bulk', {'content-type' => 'application/json; charset=utf-8'})
     request.body = bulk_message.join("\n")
     http.request(request).value

--- a/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
+++ b/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
@@ -8,6 +8,8 @@ class Fluent::MysqlReplicatorElasticsearchOutput < Fluent::BufferedOutput
   config_param :port, :integer, :default => 9200
   config_param :tag_format, :string, :default => nil
   config_param :ssl, :bool, :default => false
+  config_param :username, :string, :default => nil
+  config_param :password, :string, :default => nil
 
   DEFAULT_TAG_FORMAT = /(?<index_name>[^\.]+)\.(?<type_name>[^\.]+)\.(?<event>[^\.]+)\.(?<primary_key>[^\.]+)$/
 
@@ -64,6 +66,10 @@ class Fluent::MysqlReplicatorElasticsearchOutput < Fluent::BufferedOutput
     http.use_ssl = @ssl
 
     request = Net::HTTP::Post.new('/_bulk', {'content-type' => 'application/json; charset=utf-8'})
+    if @username && @password
+      request.basic_auth(@username, @password)
+    end
+
     request.body = bulk_message.join("\n")
     http.request(request).value
   end

--- a/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
+++ b/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
@@ -9,7 +9,7 @@ class Fluent::MysqlReplicatorElasticsearchOutput < Fluent::BufferedOutput
   config_param :tag_format, :string, :default => nil
   config_param :ssl, :bool, :default => false
   config_param :username, :string, :default => nil
-  config_param :password, :string, :default => nil
+  config_param :password, :string, :default => nil, :secret => true
 
   DEFAULT_TAG_FORMAT = /(?<index_name>[^\.]+)\.(?<type_name>[^\.]+)\.(?<event>[^\.]+)\.(?<primary_key>[^\.]+)$/
 

--- a/test/plugin/test_out_mysql_replicator_elasticsearch.rb
+++ b/test/plugin/test_out_mysql_replicator_elasticsearch.rb
@@ -132,4 +132,23 @@ class MysqlReplicatorElasticsearchOutput < Test::Unit::TestCase
     driver.run
     assert_requested(elastic_request)
   end
+
+  def test_writes_to_http_basic_auth
+    driver.configure("username foo\n")
+    driver.configure("password bar\n")
+    elastic_request = stub_elastic("http://foo:bar@localhost:9200/_bulk")
+    driver.emit(sample_record)
+    driver.run
+    assert_requested(elastic_request)
+  end
+
+  def test_writes_to_http_basic_auth_failed
+    driver.configure("username wrong_user\n")
+    driver.configure("password bar\n")
+    elastic_request = stub_elastic("http://foo:bar@localhost:9200/_bulk")
+    driver.emit(sample_record)
+    assert_raise(WebMock::NetConnectNotAllowedError) {
+      driver.run
+    }
+  end
 end

--- a/test/plugin/test_out_mysql_replicator_elasticsearch.rb
+++ b/test/plugin/test_out_mysql_replicator_elasticsearch.rb
@@ -124,4 +124,12 @@ class MysqlReplicatorElasticsearchOutput < Test::Unit::TestCase
       driver.run
     }
   end
+
+  def test_writes_to_https_host
+    driver.configure("ssl true\n")
+    elastic_request = stub_elastic("https://localhost:9200/_bulk")
+    driver.emit(sample_record)
+    driver.run
+    assert_requested(elastic_request)
+  end
 end

--- a/test/plugin/test_out_mysql_replicator_elasticsearch.rb
+++ b/test/plugin/test_out_mysql_replicator_elasticsearch.rb
@@ -134,8 +134,10 @@ class MysqlReplicatorElasticsearchOutput < Test::Unit::TestCase
   end
 
   def test_writes_to_http_basic_auth
-    driver.configure("username foo\n")
-    driver.configure("password bar\n")
+    driver.configure(%[
+      username foo\n
+      password bar\n
+    ])
     elastic_request = stub_elastic("http://foo:bar@localhost:9200/_bulk")
     driver.emit(sample_record)
     driver.run
@@ -143,8 +145,10 @@ class MysqlReplicatorElasticsearchOutput < Test::Unit::TestCase
   end
 
   def test_writes_to_http_basic_auth_failed
-    driver.configure("username wrong_user\n")
-    driver.configure("password bar\n")
+    driver.configure(%[
+      username wront_user\n
+      password bar\n
+    ])
     elastic_request = stub_elastic("http://foo:bar@localhost:9200/_bulk")
     driver.emit(sample_record)
     assert_raise(WebMock::NetConnectNotAllowedError) {


### PR DESCRIPTION
If ElasticSearch clusters are behind https proxy, this plugin needs to connect with clusters via https.
In addition, I also added basic authentication.

note: I'm a beginner in Ruby and fluent plugin development. If you find anything strange, please let me know.

