### PR TITLE
fix the connect refused issue for multi

### DIFF
--- a/lib/fluent/plugin/in_mysql_replicator_multi.rb
+++ b/lib/fluent/plugin/in_mysql_replicator_multi.rb
@@ -269,7 +269,7 @@ module Fluent
       begin
         return Mysql2::Client.new(
           :host => config['host'],
-          :port => config['manager_port'],
+          :port => config['port'],
           :username => config['username'],
           :password => config['password'],
           :database => config['database'],


### PR DESCRIPTION
Tested with multi plugin, I ran the fluentd mysql multi plugin inside docker and the mysql server is also ran in another docker. Which the port setting is incorrectly with the conf file. I modified the port then it works. Thanks