### PR TITLE
Adapt for json

### DIFF
--- a/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
+++ b/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
@@ -71,6 +71,11 @@ class Fluent::MysqlReplicatorElasticsearchOutput < Fluent::BufferedOutput
     end
 
     request.body = bulk_message.join("\n")
+
+	request.body.gsub!(/\\"/, '"')
+	request.body.gsub!(/\"{/, '{')
+	request.body.gsub!(/}\"/, '}')
+
     http.request(request).value
   end
 end

--- a/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
+++ b/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
@@ -72,9 +72,9 @@ class Fluent::MysqlReplicatorElasticsearchOutput < Fluent::BufferedOutput
 
     request.body = bulk_message.join("\n")
 
-	request.body.gsub!(/\\"/, '"')
-	request.body.gsub!(/\"{/, '{')
-	request.body.gsub!(/}\"/, '}')
+    request.body.gsub!(/\\"/, '"')
+    request.body.gsub!(/\"{/, '{')
+    request.body.gsub!(/}\"/, '}')
 
     http.request(request).value
   end


### PR DESCRIPTION
大変便利にありがたく使わせていただいております。
mysqlのフィールドにjsonを使っている場合でも、esに登録できるように改変しました。

以下は改変作業の具体的な内容となります。

---

mysqlのgeometoryフィールドに以下のようなjsonが入っており、それをesにロードしたい場合、うまくいかない事象がありました。
- {"type": "Polygon", "coordinates": [[[136.8, 35.1], [136.8001, 35.1], [136.8001, 35.10001], [136.8, 35.100012], [136.8, 35.1]]]}

そこで、esに送信しているデータを確認しましたところ、本対応前は以下のようになっていました。
- "geometry":"{\"type\": \"Polygon\", \"coordinates\": [[[136.8, 35.1], [136.8001, 35.1], [136.8001, 35.10001], [136.8, 35.100012], [136.8, 35.1]]]}"}

以下のように登録前に置換を行うように変更したところロードが成功するようになりました。
1. `「\"」を 「"」に置換`
2. `「"{」を 「{」に置換`
3. `「"}」を 「}」に置換`
