### PR TITLE
fix empty current_ids pattern when query didn't get any result

### DIFF
--- a/lib/fluent/plugin/in_mysql_replicator.rb
+++ b/lib/fluent/plugin/in_mysql_replicator.rb
@@ -101,7 +101,9 @@ module Fluent
         con.close
         ids = current_ids
         if @enable_delete
-          if previous_ids.empty?
+          if current_ids.empty?
+            deleted_ids = Array.new
+          elsif previous_ids.empty?
             deleted_ids = [*1...current_ids.max] - current_ids
           else
             deleted_ids = previous_ids - current_ids


### PR DESCRIPTION
@y-ken 
I got error when query didn't get any result.

/var/log/td-agent/td-agent.log

```
2016-06-28 14:19:12 +0900 [error]: mysql_replicator: failed to execute query.
2016-06-28 14:19:12 +0900 [error]: error: bad value for range
2016-06-28 14:19:12 +0900 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-mysql-replicator-0.5.2/lib/fluent/plugin/in_mysql_replicator.rb:105:in `block in poll'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-mysql-replicator-0.5.2/lib/fluent/plugin/in_mysql_replicator.rb:63:in `loop'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-mysql-replicator-0.5.2/lib/fluent/plugin/in_mysql_replicator.rb:63:in `poll'
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-mysql-replicator-0.5.2/lib/fluent/plugin/in_mysql_replicator.rb:50:in `run'
```

And It's happened by empty current_ids.

```
          if previous_ids.empty?
            deleted_ids = [*1...current_ids.max] - current_ids
          else
            deleted_ids = previous_ids - current_ids
          end
```

I added one conditional branching.
