### PR TITLE
Fixed Fluent::Input initialized error

### DIFF
--- a/lib/fluent/plugin/in_mysql_replicator.rb
+++ b/lib/fluent/plugin/in_mysql_replicator.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 module Fluent
   class MysqlReplicatorInput < Fluent::Input
     Plugin.register_input('mysql_replicator', self)
@@ -10,7 +12,6 @@ module Fluent
     def initialize
       require 'mysql2'
       require 'digest/sha1'
-      super
     end
 
     config_param :host, :string, :default => 'localhost'

--- a/lib/fluent/plugin/in_mysql_replicator_multi.rb
+++ b/lib/fluent/plugin/in_mysql_replicator_multi.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 module Fluent
   class MysqlReplicatorMultiInput < Fluent::Input
     Plugin.register_input('mysql_replicator_multi', self)
@@ -10,7 +12,6 @@ module Fluent
     def initialize
       require 'mysql2'
       require 'digest/sha1'
-      super
     end
 
     config_param :manager_host, :string, :default => 'localhost'


### PR DESCRIPTION
Dear y-ken

Your product `fluent-plugin-mysql-replicator` is very awesome and useful so I use this every day! I appreciate it :-)

By the way, now Fluentd's version is 0.14.10. On this version, current your source codes cause `Fluent::Input initialized` error, it seems. When `dry run`, I received the message `[error]: dry run failed: uninitialized constant Fluent::Input` though config file is correct.

I modified this error by adding code `require 'fluent/input'` on the top of source codes, `in_mysql_replicator.rb` and `in_mysql_replicator_multi.rb`.

Besides invoked `super` is no longer necessary, which warns us that `[warn]: super was not called in #start: called it forcedly plugin=Fluent::MysqlReplicatorInput`.

In case the statement above isn't my misunderstanding, please merge my codes.

Thank you for your product and best regards,
