### PR TITLE
Tweak dependancies and requires

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 
 rvm:
+  - 2.4.0
+  - 2.3.3
   - 2.2
   - 2.1
-  - 2.0.0
-  - 1.9.3
 
 services:
   - elasticsearch

--- a/fluent-plugin-mysql-replicator.gemspec
+++ b/fluent-plugin-mysql-replicator.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license = "Apache-2.0"
 
   s.add_development_dependency "rake"
-  s.add_development_dependency "webmock"
+  s.add_development_dependency "webmock", "~> 1.24.0"
   s.add_development_dependency "test-unit", ">= 3.1.0"
 
   s.add_runtime_dependency "fluentd"

--- a/lib/fluent/plugin/in_mysql_replicator.rb
+++ b/lib/fluent/plugin/in_mysql_replicator.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 module Fluent
   class MysqlReplicatorInput < Fluent::Input
     Plugin.register_input('mysql_replicator', self)

--- a/lib/fluent/plugin/in_mysql_replicator_multi.rb
+++ b/lib/fluent/plugin/in_mysql_replicator_multi.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 module Fluent
   class MysqlReplicatorMultiInput < Fluent::Input
     Plugin.register_input('mysql_replicator_multi', self)


### PR DESCRIPTION
Revised #23 and tweaking Travis Ruby versions.
Because td-agent3 will ship with Ruby 2.4.