### PR TITLE
fix syntax error when query result has a value starts with 'select'

### DIFF
--- a/lib/fluent/plugin/in_mysql_replicator.rb
+++ b/lib/fluent/plugin/in_mysql_replicator.rb
@@ -72,7 +72,7 @@ module Fluent
           current_ids << row[@primary_key]
           current_hash = Digest::SHA1.hexdigest(row.flatten.join)
           row.each {|k, v| row[k] = v.to_s if v.is_a?(Time) || v.is_a?(Date) || v.is_a?(BigDecimal)}
-          row.select {|k, v| v.to_s.strip.match(/^SELECT/i) }.each do |k, v|
+          row.select {|k, v| v.to_s.strip.match(/^SELECT(\s+)/i) }.each do |k, v|
             row[k] = [] unless row[k].is_a?(Array)
             nest_rows, prepared_con = query(v.gsub(/\$\{([^\}]+)\}/, row[$1].to_s), prepared_con)
             nest_rows.each do |nest_row|


### PR DESCRIPTION
I got warning when query result has a value starts with `select`.   
  ex. `selector2001`

```
2017-09-13 09:51:10 +0900 [warn]: mysql_replicator: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'selector2001' at line 1
2017-09-13 10:06:10 +0900 [warn]: mysql_replicator: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'selector2001' at line 1
```

And It's happened by find nested query.

```
row.select {|k, v| v.to_s.strip.match(/^SELECT/i) }.each do |k, v|
```

I added a `white space` condition with `SELECT`.