### PR TITLE
Added support for retrying when an error occurs due to the database.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ install with gem or fluent-gem command as:
 
 `````
 # for system installed fluentd
-$ gem install fluent-plugin-mysql-replicator -v 1.0.2
+$ gem install fluent-plugin-mysql-replicator -v 1.0.3
 
 # for td-agent2
 $ sudo td-agent-gem install fluent-plugin-mysql-replicator -v 0.6.1
 
 # for td-agent3
-$ sudo td-agent-gem install fluent-plugin-mysql-replicator -v 1.0.2
+$ sudo td-agent-gem install fluent-plugin-mysql-replicator -v 1.0.3
 `````
 
 ## Included plugins

--- a/fluent-plugin-mysql-replicator.gemspec
+++ b/fluent-plugin-mysql-replicator.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name        = "fluent-plugin-mysql-replicator"
-  s.version     = "1.0.2"
+  s.version     = "1.0.3"
   s.authors     = ["Kentaro Yoshida"]
   s.email       = ["y.ken.studio@gmail.com"]
   s.homepage    = "https://github.com/y-ken/fluent-plugin-mysql-replicator"

--- a/setup_mysql_replicator_multi.sql
+++ b/setup_mysql_replicator_multi.sql
@@ -30,9 +30,9 @@ CREATE TABLE IF NOT EXISTS `settings` (
   -- On enabling 'enable_loose_delete: 1', turn on speculative delete but performance penalty on non-contiguous primary key.
   `enable_loose_delete` int(11) DEFAULT '0',
   -- On enabling 'enable_retry: 1', automatically retries when an error occurs due to MySQL.
-  `enable_retry` int(11) DEFAULT '0',
+  `enable_retry` int(11) DEFAULT '1',
   -- Additional interval when retrying. If not set, waits for the time set in the regular interval column.
-  `retry_interval` int(11) NOT NULL DEFAULT 0,
+  `retry_interval` int(11) NOT NULL DEFAULT '30',
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/setup_mysql_replicator_multi.sql
+++ b/setup_mysql_replicator_multi.sql
@@ -29,6 +29,10 @@ CREATE TABLE IF NOT EXISTS `settings` (
   `enable_loose_insert` int(11) DEFAULT '0',
   -- On enabling 'enable_loose_delete: 1', turn on speculative delete but performance penalty on non-contiguous primary key.
   `enable_loose_delete` int(11) DEFAULT '0',
+  -- On enabling 'enable_retry: 1', automatically retries when an error occurs due to MySQL.
+  `enable_retry` int(11) DEFAULT '0',
+  -- Additional interval when retrying. If not set, waits for the time set in the regular interval column.
+  `retry_interval` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Added a mechanism to the resident process extraction routine that continues attempts to extract data without stopping the process, even if extraction errors occur when the target database is shutdown or restarted for periodic maintenance, etc.
To maintain compatibility with the existing behavior, this retry feature can be turned on or off at will.