### PR TITLE
Support Elasticsearch 8.x and 9.x (auto-detect version), release v1.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,23 @@ jobs:
       - run: bundle exec rake test
 
   e2e:
-    name: E2E replication (MySQL -> Elasticsearch)
+    name: E2E replication (ES ${{ matrix.es_label }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The plugin auto-detects the version and adjusts "_type" accordingly.
+          - es_label: '6.8'
+            es_image: docker.elastic.co/elasticsearch/elasticsearch:6.8.23
+            es_major: '6'
+          - es_label: '8.x'
+            es_image: docker.elastic.co/elasticsearch/elasticsearch:8.18.0
+            es_major: '8'
+          - es_label: '9.x'
+            es_image: docker.elastic.co/elasticsearch/elasticsearch:9.0.0
+            es_major: '9'
 
     services:
       mysql:
@@ -41,9 +56,10 @@ jobs:
           --health-retries=10
 
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:6.8.23
+        image: ${{ matrix.es_image }}
         env:
           discovery.type: single-node
+          xpack.security.enabled: 'false'
           ES_JAVA_OPTS: -Xms512m -Xmx512m
         ports:
           - 9200:9200
@@ -56,6 +72,7 @@ jobs:
       MYSQL_DATABASE: e2e_source
       ES_HOST: 127.0.0.1
       ES_PORT: 9200
+      ES_MAJOR_VERSION: ${{ matrix.es_major }}
 
     steps:
       - uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ bundle exec ruby -Itest test/plugin/test_out_mysql_replicator_elasticsearch.rb
 * Output Plugin: mysql_replicator_elasticsearch
 * Output Plugin: mysql_replicator_solr (experimental)
 
+## Elasticsearch version compatibility
+
+`mysql_replicator_elasticsearch` works with Elasticsearch 6.x through 9.x.
+
+Mapping types were removed in Elasticsearch 8.x (and deprecated in 7.x), so the
+`_type` field can no longer be sent in bulk requests. The plugin detects the
+Elasticsearch version on the first write and automatically omits `_type` for
+7.x and later, so no extra configuration is required.
+
 ## Output example
 
 It is a example when detecting insert/update/delete events.

--- a/fluent-plugin-mysql-replicator.gemspec
+++ b/fluent-plugin-mysql-replicator.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name        = "fluent-plugin-mysql-replicator"
-  s.version     = "1.0.3"
+  s.version     = "1.1.0"
   s.authors     = ["Kentaro Yoshida"]
   s.email       = ["y.ken.studio@gmail.com"]
   s.homepage    = "https://github.com/y-ken/fluent-plugin-mysql-replicator"

--- a/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
+++ b/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
@@ -39,6 +39,8 @@ class Fluent::Plugin::MysqlReplicatorElasticsearchOutput < Fluent::Plugin::Outpu
 
   def start
     super
+    # nil means "not yet detected"; resolved on the first write.
+    @suppress_type = nil
   end
 
   def format(tag, time, record)
@@ -58,6 +60,8 @@ class Fluent::Plugin::MysqlReplicatorElasticsearchOutput < Fluent::Plugin::Outpu
   end
 
   def write(chunk)
+    detect_type_suppression if @suppress_type.nil?
+
     bulk_message = []
 
     chunk.msgpack_each do |tag, time, record|
@@ -67,21 +71,22 @@ class Fluent::Plugin::MysqlReplicatorElasticsearchOutput < Fluent::Plugin::Outpu
       id_key = tag_parts['primary_key']
 
       if tag_parts['event'] == 'delete'
-        meta = { "delete" => {"_index" => target_index, "_type" => target_type, "_id" => record[id_key]} }
+        action = {"_index" => target_index, "_id" => record[id_key]}
+        action['_type'] = target_type unless @suppress_type
+        meta = { "delete" => action }
         bulk_message << Yajl::Encoder.encode(meta)
       else
-        meta = { "index" => {"_index" => target_index, "_type" => target_type} }
+        action = {"_index" => target_index}
+        action['_type'] = target_type unless @suppress_type
         if id_key && record[id_key]
-          meta['index']['_id'] = record[id_key]
+          action['_id'] = record[id_key]
         end
+        meta = { "index" => action }
         bulk_message << Yajl::Encoder.encode(meta)
         bulk_message << Yajl::Encoder.encode(record)
       end
     end
     bulk_message << ""
-
-    http = Net::HTTP.new(@host, @port.to_i)
-    http.use_ssl = @ssl
 
     request = Net::HTTP::Post.new('/_bulk', {'content-type' => 'application/json; charset=utf-8'})
     if @username && @password
@@ -89,6 +94,37 @@ class Fluent::Plugin::MysqlReplicatorElasticsearchOutput < Fluent::Plugin::Outpu
     end
 
     request.body = bulk_message.join("\n")
-    http.request(request).value
+    new_http.request(request).value
+  end
+
+  private
+
+  def new_http
+    http = Net::HTTP.new(@host, @port.to_i)
+    http.use_ssl = @ssl
+    http
+  end
+
+  # Mapping types were removed in Elasticsearch 8.x and deprecated in 7.x.
+  # Detect the major version once and omit "_type" for 7.x and later.
+  def detect_type_suppression
+    major = elasticsearch_major_version
+    @suppress_type = !major.nil? && major >= 7
+    if major
+      log.info "mysql_replicator_elasticsearch: detected Elasticsearch #{major}.x, suppress_type=#{@suppress_type}"
+    else
+      log.warn "mysql_replicator_elasticsearch: could not detect Elasticsearch version, sending '_type' (assuming 6.x)"
+    end
+  end
+
+  def elasticsearch_major_version
+    request = Net::HTTP::Get.new('/')
+    request.basic_auth(@username, @password) if @username && @password
+    response = new_http.request(request)
+    number = Yajl::Parser.parse(response.body).dig('version', 'number')
+    number.to_s.split('.').first.to_i
+  rescue => e
+    log.warn "mysql_replicator_elasticsearch: version detection failed: #{e.message}"
+    nil
   end
 end

--- a/test/e2e/e2e_helper.rb
+++ b/test/e2e/e2e_helper.rb
@@ -27,9 +27,17 @@ module E2E
     "http://#{ENV['ES_HOST'] || '127.0.0.1'}:#{ENV['ES_PORT'] || '9200'}"
   end
 
+  # Major version of the Elasticsearch under test (defaults to 6).
+  def es_major_version
+    (ENV['ES_MAJOR_VERSION'] || '6').to_i
+  end
+
   # Realtime GET by id. Returns [http_status, parsed_body].
+  # Elasticsearch 7.x+ dropped custom mapping types, so documents are addressed
+  # via the "_doc" endpoint instead of the original type name.
   def es_get(index, type, id)
-    res = Net::HTTP.get_response(URI("#{es_base}/#{index}/#{type}/#{id}"))
+    type_path = es_major_version >= 7 ? '_doc' : type
+    res = Net::HTTP.get_response(URI("#{es_base}/#{index}/#{type_path}/#{id}"))
     [res.code.to_i, (JSON.parse(res.body) rescue {})]
   end
 

--- a/test/plugin/test_out_mysql_replicator_elasticsearch.rb
+++ b/test/plugin/test_out_mysql_replicator_elasticsearch.rb
@@ -21,7 +21,18 @@ class MysqlReplicatorElasticsearchOutput < Test::Unit::TestCase
     {'age' => 26, 'request_id' => '42'}
   end
 
+  # The plugin detects the Elasticsearch version on the first write via GET /,
+  # so stub that endpoint (defaulting to 6.x, which keeps "_type").
+  def stub_elastic_version(url, version="6.8.23")
+    stub_request(:get, url).to_return(
+      :status => 200,
+      :headers => {"Content-Type" => "application/json"},
+      :body => %({"version":{"number":"#{version}"}})
+    )
+  end
+
   def stub_elastic(url="http://localhost:9200/_bulk")
+    stub_elastic_version(url.sub('/_bulk', '/'))
     stub_request(:post, url).with do |req|
       @content_type = req.headers["Content-Type"]
       @index_cmds = req.body.split("\n").map {|r| JSON.parse(r) }
@@ -29,6 +40,7 @@ class MysqlReplicatorElasticsearchOutput < Test::Unit::TestCase
   end
 
   def stub_elastic_unavailable(url="http://localhost:9200/_bulk")
+    stub_elastic_version(url.sub('/_bulk', '/'))
     stub_request(:post, url).to_return(:status => [503, "Service Unavailable"])
   end
 
@@ -56,6 +68,16 @@ class MysqlReplicatorElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record)
     end
     assert_equal('mytype', index_cmds.first['index']['_type'])
+  end
+
+  def test_auto_detects_es8_and_omits_type
+    stub_elastic
+    # Override the version endpoint to report Elasticsearch 8.x.
+    stub_elastic_version("http://localhost:9200/", "8.18.0")
+    driver.run(default_tag: @tag) do
+      driver.feed(sample_record)
+    end
+    assert(!index_cmds.first['index'].has_key?('_type'))
   end
 
   def test_writes_to_speficied_host


### PR DESCRIPTION
## Summary

Adds Elasticsearch 8.x / 9.x compatibility to `mysql_replicator_elasticsearch` and bumps the gem to **v1.1.0**.

Elasticsearch 8.x removed mapping types, so `_type` can no longer be sent in bulk requests. The plugin **auto-detects the Elasticsearch version** on the first write (`GET /`) and omits `_type` for 7.x and later. No configuration is required.

## Changes

- **`out_mysql_replicator_elasticsearch`**: detects the Elasticsearch major version on the first write and caches the result. `_type` is dropped for ES ≥ 7 and kept for ES 6. Version detection reuses the same host/SSL/auth as the bulk request. On detection failure it logs a warning and falls back to sending `_type` (6.x behavior).
- **No new config option**: the `_type` decision is an internal variable — there is nothing for users to set.
- **Unit tests**: stub the version endpoint (defaulting to 6.x so existing assertions hold) and add a case asserting `_type` is omitted when the cluster reports 8.x.
- **E2E**: the replication matrix now runs against **Elasticsearch 6.8 / 8.18 / 9.0**, relying on auto-detection. Documents are read back via `_doc` on 7.x+.
- **README**: documents version compatibility (no configuration needed).
- **Version**: `1.0.3` → `1.1.0` (backward-compatible feature addition).

## Notes

- Targets the `add-devcontainer-and-e2e-ci` branch (stacked on the CI/E2E work), so this PR shows only the ES 8/9 diff. Merge #46 first.
- ES image tags (8.18.0 / 9.0.0) can be adjusted if newer patch releases are preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)