### PR TITLE
Add JSON column support for nested object indexing

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3-slim
+FROM ruby:3.4-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV BUNDLE_PATH=/workspace/vendor/bundle

--- a/README.md
+++ b/README.md
@@ -88,6 +88,40 @@ Mapping types were removed in Elasticsearch 8.x (and deprecated in 7.x), so the
 Elasticsearch version on the first write and automatically omits `_type` for
 7.x and later, so no extra configuration is required.
 
+## JSON column support
+
+MySQL `JSON` columns (MySQL 5.7.8+ / 8.x) are returned by the driver as plain
+strings, so by default they reach Elasticsearch as escaped strings rather than
+nested objects. List such columns in `json_columns` to have their values parsed
+into nested objects before they are emitted.
+
+* `mysql_replicator` (single): set the `json_columns` option (comma-separated).
+
+  ```
+  <source>
+    @type        mysql_replicator
+    # ...
+    query        SELECT id, name, geometry FROM places
+    json_columns geometry,attrs
+  </source>
+  ```
+
+* `mysql_replicator_multi`: set the `json_columns` column (comma-separated) on
+  the relevant row of the `settings` management table. Existing installs can add
+  the column with:
+
+  ```sql
+  ALTER TABLE settings ADD COLUMN `json_columns` varchar(255) DEFAULT NULL AFTER `primary_key`;
+  ```
+
+Notes:
+
+* This option is intended for Elasticsearch. **Do not set it when the destination
+  cannot store JSON objects (e.g. the Solr output)** — leave it empty there.
+* Only top-level columns are parsed (columns inside nested documents are not).
+* Malformed JSON and non-string values are left untouched, so enabling the option
+  never corrupts non-JSON data.
+
 ## Output example
 
 It is a example when detecting insert/update/delete events.

--- a/lib/fluent/plugin/in_mysql_replicator.rb
+++ b/lib/fluent/plugin/in_mysql_replicator.rb
@@ -1,5 +1,6 @@
 require 'mysql2'
 require 'digest/sha1'
+require 'json'
 require 'fluent/plugin/input'
 
 module Fluent::Plugin
@@ -19,6 +20,10 @@ module Fluent::Plugin
     config_param :primary_key, :string, :default => 'id'
     config_param :interval, :string, :default => '1m'
     config_param :enable_delete, :bool, :default => true
+    # Comma-separated column names whose MySQL JSON values should be parsed into
+    # nested objects before emitting. Intended for Elasticsearch; do not set it
+    # when the destination cannot store JSON objects (e.g. Solr).
+    config_param :json_columns, :array, :default => []
     config_param :tag, :string, :default => nil
 
     def configure(conf)
@@ -29,7 +34,7 @@ module Fluent::Plugin
         raise Fluent::ConfigError, "mysql_replicator: missing 'tag' parameter. Please add following line into config like 'tag replicator.mydatabase.mytable.${event}.${primary_key}'"
       end
 
-      log.info "adding mysql_replicator worker. :tag=>#{tag} :query=>#{@query} :prepared_query=>#{@prepared_query} :interval=>#{@interval}sec :enable_delete=>#{enable_delete}"
+      log.info "adding mysql_replicator worker. :tag=>#{tag} :query=>#{@query} :prepared_query=>#{@prepared_query} :interval=>#{@interval}sec :enable_delete=>#{enable_delete} :json_columns=>#{@json_columns}"
     end
 
     def start
@@ -71,6 +76,7 @@ module Fluent::Plugin
           current_ids << row[@primary_key]
           current_hash = Digest::SHA1.hexdigest(row.flatten.join)
           row.each {|k, v| row[k] = v.to_s if v.is_a?(Time) || v.is_a?(Date) || v.is_a?(BigDecimal)}
+          parse_json_columns!(row, @json_columns)
           row.select {|k, v| nested_query_value?(v) }.each do |k, v|
             row[k] = [] unless row[k].is_a?(Array)
             nest_rows, prepared_con = query(v.gsub(/\$\{([^\}]+)\}/, row[$1].to_s), prepared_con)
@@ -127,6 +133,22 @@ module Fluent::Plugin
       return [] if previous_ids.empty?
       return [] if current_ids.empty?
       previous_ids - current_ids
+    end
+
+    # Parse the given columns' JSON string values into nested objects in place.
+    # Non-string values, missing columns, and malformed JSON are left untouched
+    # so enabling this never corrupts non-JSON data.
+    def parse_json_columns!(row, columns)
+      return if columns.empty?
+      columns.each do |col|
+        v = row[col]
+        next unless v.is_a?(String)
+        begin
+          row[col] = JSON.parse(v)
+        rescue JSON::ParserError
+          # leave the original string as-is on malformed JSON
+        end
+      end
     end
 
     def format_tag(tag, param)

--- a/lib/fluent/plugin/in_mysql_replicator_multi.rb
+++ b/lib/fluent/plugin/in_mysql_replicator_multi.rb
@@ -9,6 +9,7 @@ module Fluent::Plugin
     def initialize
       require 'mysql2'
       require 'digest/sha1'
+      require 'json'
       super
     end
 
@@ -81,6 +82,7 @@ module Fluent::Plugin
           log.info "mysql_replicator_multi: polling start. :config=>#{masked_config}"
         }
         primary_key = config['primary_key']
+        json_columns = (config['json_columns'] || '').split(',').map(&:strip).reject(&:empty?)
         previous_id = current_id = nil
         while @running
           rows_count = 0
@@ -97,6 +99,7 @@ module Fluent::Plugin
             db = get_origin_connection(config)
             db.query(config['query']).each do |row|
               row.each {|k, v| row[k] = v.to_s if v.is_a?(Time) || v.is_a?(Date) || v.is_a?(BigDecimal)}
+              parse_json_columns!(row, json_columns)
               row.select {|k, v| v.to_s.strip.match(/^SELECT[^\$]+\$\{[^\}]+\}/i) }.each do |k, v|
                 row[k] = [] unless row[k].is_a?(Array)
                 nest_db.query(v.gsub(/\$\{([^\}]+)\}/) {|matched| row[$1].to_s}).each do |nest_row|
@@ -264,6 +267,22 @@ module Fluent::Plugin
       @manager_db.query(query)
       @hash_table_bulk_insert.clear
       @hash_table_bulk_insert_last_time = Time.now
+    end
+
+    # Parse the given columns' JSON string values into nested objects in place.
+    # Non-string values, missing columns, and malformed JSON are left untouched
+    # so enabling this never corrupts non-JSON data.
+    def parse_json_columns!(row, columns)
+      return if columns.empty?
+      columns.each do |col|
+        v = row[col]
+        next unless v.is_a?(String)
+        begin
+          row[col] = JSON.parse(v)
+        rescue JSON::ParserError
+          # leave the original string as-is on malformed JSON
+        end
+      end
     end
 
     def emit_record(tag, record)

--- a/setup_mysql_replicator_multi.sql
+++ b/setup_mysql_replicator_multi.sql
@@ -24,6 +24,9 @@ CREATE TABLE IF NOT EXISTS `settings` (
   `prepared_query` TEXT NOT NULL,
   `interval` int(11) NOT NULL,
   `primary_key` varchar(255) DEFAULT 'id',
+  -- Comma-separated column names whose MySQL JSON values should be parsed into nested objects.
+  -- Intended for Elasticsearch; leave empty for Solr or destinations that cannot store JSON objects.
+  `json_columns` varchar(255) DEFAULT NULL,
   `enable_delete` int(11) DEFAULT '1',
   -- On enabling 'enable_loose_insert: 1', make it faster synchronization to skip checking hash_tables.
   `enable_loose_insert` int(11) DEFAULT '0',

--- a/test/e2e/fluent_single.conf
+++ b/test/e2e/fluent_single.conf
@@ -8,8 +8,9 @@
   username "#{ENV['MYSQL_USER'] || 'root'}"
   password "#{ENV['MYSQL_PASSWORD'] || 'root'}"
   database "#{ENV['MYSQL_DATABASE'] || 'e2e_source'}"
-  query SELECT id, name, age FROM users
+  query SELECT id, name, age, profile FROM users
   primary_key id
+  json_columns profile
   interval 2s
   enable_delete true
   tag myindex.mytype.${event}.${primary_key}

--- a/test/e2e/replication_multi_e2e_test.rb
+++ b/test/e2e/replication_multi_e2e_test.rb
@@ -41,13 +41,19 @@ client.query("CREATE DATABASE `#{SOURCE_DB}`")
 client.query("USE `#{SOURCE_DB}`")
 client.query(<<~SQL)
   CREATE TABLE users (
-    id   INT NOT NULL AUTO_INCREMENT,
-    name VARCHAR(255) NOT NULL,
-    age  INT NOT NULL,
+    id      INT NOT NULL AUTO_INCREMENT,
+    name    VARCHAR(255) NOT NULL,
+    age     INT NOT NULL,
+    profile JSON,
     PRIMARY KEY (id)
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8
 SQL
-client.query("INSERT INTO users (name, age) VALUES ('alice', 20), ('bob', 30), ('carol', 40)")
+client.query(<<~SQL)
+  INSERT INTO users (name, age, profile) VALUES
+    ('alice', 20, '{"city":"Tokyo","tags":["a","b"]}'),
+    ('bob',   30, '{"city":"Osaka","tags":["c"]}'),
+    ('carol', 40, '{"city":"Nagoya","tags":[]}')
+SQL
 
 # --- 2. Build the management database and register a replication setting ----
 step "building management database '#{MANAGER_DB}' from setup SQL"
@@ -61,11 +67,11 @@ cfg = mysql_config
 client.query(<<~SQL)
   INSERT INTO `#{MANAGER_DB}`.settings
     (is_active, name, host, port, username, password, `database`,
-     query, prepared_query, `interval`, primary_key, enable_delete)
+     query, prepared_query, `interval`, primary_key, enable_delete, json_columns)
   VALUES
     (1, '#{SETTING_NAME}', '#{cfg[:host]}', #{cfg[:port]},
      '#{cfg[:username]}', '#{client.escape(cfg[:password].to_s)}', '#{SOURCE_DB}',
-     'SELECT id, name, age FROM users ORDER BY id', '', 2, 'id', 1)
+     'SELECT id, name, age, profile FROM users ORDER BY id', '', 2, 'id', 1, 'profile')
 SQL
 
 # --- 3. Boot Fluentd --------------------------------------------------------
@@ -82,6 +88,18 @@ begin
     end
   end
   step "  INSERT OK"
+
+  # --- 4b. JSON column is indexed as a nested object (not an escaped string) -
+  step "asserting JSON column is replicated as a nested object"
+  wait_until("user 1 profile.city == Tokyo in Elasticsearch", log_path: LOG_PATH) do
+    code, body = es_get(INDEX, TYPE, 1)
+    code == 200 && body.dig('_source', 'profile', 'city') == 'Tokyo'
+  end
+  _, body = es_get(INDEX, TYPE, 1)
+  unless body.dig('_source', 'profile', 'tags') == ['a', 'b']
+    fail_with("profile was not indexed as a nested object: #{body.dig('_source', 'profile').inspect}", LOG_PATH)
+  end
+  step "  JSON OK"
 
   # --- 5. hash_tables state is persisted ------------------------------------
   step "asserting hash_tables persistence"

--- a/test/e2e/replication_single_e2e_test.rb
+++ b/test/e2e/replication_single_e2e_test.rb
@@ -24,13 +24,18 @@ client.query("CREATE DATABASE `#{DB}`")
 client.query("USE `#{DB}`")
 client.query(<<~SQL)
   CREATE TABLE users (
-    id   INT NOT NULL AUTO_INCREMENT,
-    name VARCHAR(255) NOT NULL,
-    age  INT NOT NULL,
+    id      INT NOT NULL AUTO_INCREMENT,
+    name    VARCHAR(255) NOT NULL,
+    age     INT NOT NULL,
+    profile JSON,
     PRIMARY KEY (id)
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8
 SQL
-client.query("INSERT INTO users (name, age) VALUES ('alice', 20), ('bob', 30)")
+client.query(<<~SQL)
+  INSERT INTO users (name, age, profile) VALUES
+    ('alice', 20, '{"city":"Tokyo","tags":["a","b"]}'),
+    ('bob',   30, '{"city":"Osaka","tags":["c"]}')
+SQL
 
 # --- 2. Boot Fluentd --------------------------------------------------------
 step "starting Fluentd (#{CONF})"
@@ -48,6 +53,18 @@ begin
     code == 200 && body.dig('_source', 'name') == 'bob'
   end
   step "  INSERT OK"
+
+  # --- 3b. JSON column is indexed as a nested object (not an escaped string) -
+  step "asserting JSON column is replicated as a nested object"
+  wait_until("user 1 profile.city == Tokyo in Elasticsearch", log_path: LOG_PATH) do
+    code, body = es_get(INDEX, TYPE, 1)
+    code == 200 && body.dig('_source', 'profile', 'city') == 'Tokyo'
+  end
+  _, body = es_get(INDEX, TYPE, 1)
+  unless body.dig('_source', 'profile', 'tags') == ['a', 'b']
+    fail_with("profile was not indexed as a nested object: #{body.dig('_source', 'profile').inspect}", LOG_PATH)
+  end
+  step "  JSON OK"
 
   # --- 4. UPDATE is replicated ----------------------------------------------
   step "asserting UPDATE replication"

--- a/test/plugin/test_in_mysql_replicator.rb
+++ b/test/plugin/test_in_mysql_replicator.rb
@@ -30,12 +30,45 @@ class MysqlReplicatorInputTest < Test::Unit::TestCase
       tag             input.mysql
       query           SELECT id, text from search_text
       enable_delete   no
+      json_columns    geometry,attrs
     ]
     assert_equal 'localhost', d.instance.host
     assert_equal 3306, d.instance.port
     assert_equal 30, d.instance.interval
     assert_equal 'input.mysql', d.instance.tag
     assert_equal false, d.instance.enable_delete
+    assert_equal ['geometry', 'attrs'], d.instance.json_columns
+  end
+
+  def test_json_columns_defaults_to_empty
+    d = create_driver
+    assert_equal [], d.instance.json_columns
+  end
+
+  def test_parse_json_columns
+    d = create_driver
+    row = {
+      'id'       => 1,
+      'geometry' => '{"type":"Polygon","coordinates":[[136.8,35.1]]}',
+      'tags'     => '[1,2,3]',
+      'broken'   => 'not json {',
+      'plain'    => 'hello',
+      'number'   => 5,
+    }
+    d.instance.parse_json_columns!(row, ['geometry', 'tags', 'broken', 'number', 'missing'])
+
+    assert_equal({'type' => 'Polygon', 'coordinates' => [[136.8, 35.1]]}, row['geometry'])
+    assert_equal([1, 2, 3], row['tags'])
+    assert_equal('not json {', row['broken'])  # malformed JSON stays as the original string
+    assert_equal(5, row['number'])             # non-string values are untouched
+    assert_equal('hello', row['plain'])        # columns not listed are untouched
+  end
+
+  def test_parse_json_columns_noop_when_empty
+    d = create_driver
+    row = {'geometry' => '{"a":1}'}
+    d.instance.parse_json_columns!(row, [])
+    assert_equal('{"a":1}', row['geometry'])
   end
 
   # --- #42: delete detection must not build an integer Range from primary keys ---


### PR DESCRIPTION
## Summary

MySQL `JSON` columns (MySQL 5.7.8+ / 8.x) are returned by the driver as plain
strings, so they reached Elasticsearch as **escaped strings** instead of nested
objects (e.g. `"geometry":"{\"type\":\"Polygon\",...}"`). This made them
unusable for indexing.

This PR adds an opt-in `json_columns` option that parses the listed columns'
values into nested objects before they are emitted, so they are indexed as real
nested JSON.

This implements the request from #18 in a type-safe, opt-in way (instead of the
unconditional string replacement proposed there). It supersedes #18.

## Changes

- **`mysql_replicator` (single)**: new `json_columns` config_param (comma-separated).
- **`mysql_replicator_multi`**: new `json_columns` column on the `settings`
  management table (`varchar(255)`). Existing installs can migrate with:
  ```sql
  ALTER TABLE settings ADD COLUMN `json_columns` varchar(255) DEFAULT NULL AFTER `primary_key`;
  ```
- Malformed JSON, non-string values, and unlisted columns are left untouched, so
  the **default behavior is unchanged** (no side effects).
- Documented in the README that this targets Elasticsearch — leave it empty for
  Solr or destinations that cannot store JSON objects.

## Notes / scope

- Only top-level columns are parsed (columns inside nested documents are not).
- Diff detection is unaffected: the single plugin hashes the raw string, the
  multi plugin hashes the parsed value, and MySQL returns JSON in a normalized
  form so both are stable across scans.

## Testing

- **Unit tests** (Ruby 3.4): config parsing + `parse_json_columns!` (valid
  object/array, malformed JSON, non-string, unlisted, empty). All plugin tests
  pass, no regressions.
- **E2E** (MySQL 8.4 + Elasticsearch 8.18): both single and multi pipelines
  assert a JSON column is replicated as a nested object
  (`_source.profile.city == "Tokyo"`, `_source.profile.tags == ["a","b"]`)
  alongside the existing insert/update/delete checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)