### PR TITLE
docs: clarify native-extension install deps and replicator mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,28 @@ It's comming support replicate to another RDB/noSQL.
 
 ## Dependency
 
-before use, install dependent library as:
+This plugin depends on the [mysql2](https://rubygems.org/gems/mysql2) gem, which
+builds a native extension at install time. You need both a C compiler toolchain
+**and the MySQL client development headers** before installing.
 
 ```bash
-# for RHEL/CentOS
+# for RHEL/CentOS/Fedora
 $ sudo yum group install "Development Tools"
+$ sudo yum install mysql-devel        # or mariadb-devel
 
-# for Ubuntu/Debian
-$ sudo apt-get install build-essential
+# for Ubuntu/Debian (including the official fluent/fluentd Docker image)
+$ sudo apt-get install build-essential default-libmysqlclient-dev
+```
+
+### Troubleshooting: "Failed to build gem native extension"
+
+If `gem install` (or `td-agent-gem install`) fails while building the `mysql2`
+native extension, the MySQL client headers are almost always missing. Install
+the development package for your platform shown above, then retry the
+installation. On the official `fluent/fluentd:*-debian` images, run:
+
+```bash
+$ apt-get update && apt-get install -y build-essential default-libmysqlclient-dev
 ```
 
 ## Installation

--- a/Tutorial-mysql_replicator.md
+++ b/Tutorial-mysql_replicator.md
@@ -8,6 +8,26 @@ It is useful for these purpose.
 **Note:**  
 On syncing 300 million rows table, it will consume around 800MB of memory with ruby 1.9.3 environment.
 
+### How it works
+
+`mysql_replicator` does **not** rely on any `updated_at`/timestamp column to
+detect changes. On every `interval`, it re-runs the configured `query`, computes
+a hash for each returned row, and keeps an **in-memory hash table of every row**
+(keyed by `primary_key`) to compare against the previous run:
+
+* a row whose `primary_key` was not seen before → `insert` event
+* a row whose hash changed since the previous run → `update` event
+* a `primary_key` that disappeared from the result set → `delete` event (when `enable_delete yes`)
+
+Because the whole result set is held in memory, this plugin is best suited for
+small-to-medium tables. For millions of rows or multiple tables, prefer
+[`mysql_replicator_multi`](Tutorial-mysql_replicator_multi.md), which stores the
+hash table in a MySQL management table instead of Ruby memory.
+
+The `updated_at` column is therefore not required. It only becomes useful if you
+intentionally narrow the `query` to recently changed rows together with
+`enable_delete no`, as shown in the `enable_delete` comment below.
+
 ### configuration
 
 `````
@@ -21,7 +41,7 @@ On syncing 300 million rows table, it will consume around 800MB of memory with r
   database myweb
 
   # Set replicate query configuration.
-  query SELECT id, text, updated_at from search_test;
+  query SELECT id, text from search_test;
   primary_key id # specify unique key (default: id)
   interval 10s  # execute query interval (default: 1m)
 


### PR DESCRIPTION
## Summary

Documentation-only PR (P1 of the issue-cleanup plan). No code changes.

### README — install / native extension (#43, basis for #16)
- Clarify that the plugin depends on `mysql2`, which builds a **native extension**
  at install time and therefore needs the **MySQL client development headers**
  (`default-libmysqlclient-dev` on Debian/Ubuntu, `mysql-devel`/`mariadb-devel`
  on RHEL), not just a compiler.
- Add a **"Failed to build gem native extension"** troubleshooting section,
  including the exact command for the official `fluent/fluentd:*-debian` Docker
  image (the answer @y-ken already gave in #43, now persisted in the docs).

### Tutorial-mysql_replicator — how it works (#40)
- Remove the misleading `updated_at` from the basic sample query.
- Add a **"How it works"** section stating explicitly that change detection does
  **not** use any timestamp column, but an **in-memory hash table of every row**
  (insert/update/delete semantics described), and point large/multi-table users
  to `mysql_replicator_multi`.

## Issues
- Closes #43
- Closes #40
- Provides the canonical install guidance behind #16 (stale; can be closed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)