### PR TITLE
ci: add install smoke tests for fluent-package v6 LTS and fluentd edge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,16 +101,17 @@ jobs:
       - name: Run multi-table replication E2E test
         run: bundle exec ruby test/e2e/replication_multi_e2e_test.rb
 
-  install-smoke:
-    name: Install smoke (fluentd ${{ matrix.fluentd_tag }})
+  # Container path: the official fluent/fluentd Docker image (gem-based).
+  install-smoke-docker:
+    name: Install smoke (Docker fluent/fluentd ${{ matrix.fluentd_tag }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        # An older line close to the originally reported image (#43 used
-        # v1.15-debian) plus the moving "edge" tag to catch future drift.
-        fluentd_tag: ['v1.16-debian', 'edge-debian']
+        # "edge" tracks the latest Fluentd release to catch drift early. The
+        # packaged-distribution path is covered by install-smoke-fluent-package.
+        fluentd_tag: ['edge-debian']
 
     steps:
       - uses: actions/checkout@v5
@@ -130,3 +131,35 @@ jobs:
             -v "${{ github.workspace }}:/workspace:ro" \
             "fluent/fluentd:${{ matrix.fluentd_tag }}" \
             /workspace/ci/install_smoke.sh
+
+  # Package path: fluent-package, the LTS distribution that replaced td-agent
+  # and is what most production users run today. v6 LTS bundles Fluentd v1.19.
+  install-smoke-fluent-package:
+    name: Install smoke (fluent-package v6 LTS)
+    runs-on: ubuntu-latest  # GitHub's ubuntu-latest is Ubuntu 24.04 (Noble)
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+
+      - name: Build gem
+        run: |
+          mkdir -p pkg
+          gem build fluent-plugin-mysql-replicator.gemspec -o pkg/fluent-plugin-mysql-replicator.gem
+
+      - name: Install fluent-package v6 LTS
+        run: |
+          curl -fsSL https://fluentd.cdn.cncf.io/sh/install-ubuntu-noble-fluent-package6-lts.sh | sh
+          /opt/fluent/bin/fluentd --version
+
+      - name: Install MySQL client headers
+        run: sudo apt-get update && sudo apt-get install -y build-essential default-libmysqlclient-dev
+
+      - name: Install plugin via fluent-gem and verify it loads
+        run: |
+          sudo /opt/fluent/bin/fluent-gem install pkg/fluent-plugin-mysql-replicator.gem
+          sudo /opt/fluent/bin/fluent-gem list fluent-plugin-mysql-replicator
+          /opt/fluent/bin/ruby ci/verify_plugins_load.rb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,33 @@ jobs:
 
       - name: Run multi-table replication E2E test
         run: bundle exec ruby test/e2e/replication_multi_e2e_test.rb
+
+  install-smoke:
+    name: Install smoke (fluentd ${{ matrix.fluentd_tag }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # An older line close to the originally reported image (#43 used
+        # v1.15-debian) plus the moving "edge" tag to catch future drift.
+        fluentd_tag: ['v1.16-debian', 'edge-debian']
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+
+      - name: Build gem
+        run: |
+          mkdir -p pkg
+          gem build fluent-plugin-mysql-replicator.gemspec -o pkg/fluent-plugin-mysql-replicator.gem
+
+      - name: Install on official fluentd image (reproduces README steps)
+        run: |
+          docker run --rm --user root --entrypoint sh \
+            -v "${{ github.workspace }}:/workspace:ro" \
+            "fluent/fluentd:${{ matrix.fluentd_tag }}" \
+            /workspace/ci/install_smoke.sh

--- a/ci/install_smoke.sh
+++ b/ci/install_smoke.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Install smoke test: reproduces the README install steps inside the official
+# fluent/fluentd Debian image to verify the mysql2 native extension actually
+# builds and the plugins load. Guards against the "Failed to build gem native
+# extension" class of breakage reported in #43 / #16 / #35.
+set -eux
+
+GEM_FILE="${GEM_FILE:-/workspace/pkg/fluent-plugin-mysql-replicator.gem}"
+
+# Build toolchain + MySQL client development headers (the bit users forget).
+apt-get update
+apt-get install -y build-essential default-libmysqlclient-dev
+
+# Installing the gem compiles the mysql2 native extension; this fails loudly
+# if the client headers are missing, which is exactly what we want to catch.
+gem install "$GEM_FILE"
+
+# Confirm the installed plugins (and the mysql2 native extension) load at runtime.
+ruby -e 'require "fluent/plugin/in_mysql_replicator"; require "fluent/plugin/in_mysql_replicator_multi"; puts "input plugins loaded; mysql2 native extension OK"'

--- a/ci/install_smoke.sh
+++ b/ci/install_smoke.sh
@@ -16,4 +16,4 @@ apt-get install -y build-essential default-libmysqlclient-dev
 gem install "$GEM_FILE"
 
 # Confirm the installed plugins (and the mysql2 native extension) load at runtime.
-ruby -e 'require "fluent/plugin/in_mysql_replicator"; require "fluent/plugin/in_mysql_replicator_multi"; puts "input plugins loaded; mysql2 native extension OK"'
+ruby "$(dirname "$0")/verify_plugins_load.rb"

--- a/ci/verify_plugins_load.rb
+++ b/ci/verify_plugins_load.rb
@@ -1,0 +1,5 @@
+# Loads the plugins to confirm they (and the mysql2 native extension) are
+# usable at runtime after a fresh install. Shared by both install-smoke jobs.
+require "fluent/plugin/in_mysql_replicator"
+require "fluent/plugin/in_mysql_replicator_multi"
+puts "input plugins loaded; mysql2 native extension OK"


### PR DESCRIPTION
## Summary

Adds `install-smoke` CI coverage that **reproduces the real install paths users run today**, so the "Failed to build gem native extension" class of breakage is caught automatically instead of by end users.

td-agent's successor is **fluent-package**; v5 (Fluentd v1.16) reached EOL in
Dec 2025, and **v6 LTS (Fluentd v1.19)** is current. So this tests:

### `install-smoke-fluent-package` — the production package path
Installs **fluent-package v6 LTS** on Ubuntu Noble (`ubuntu-latest`), then
`fluent-gem install`s the built gem via `/opt/fluent/bin`, compiling the mysql2
native extension and loading the plugins. This mirrors what packaged-distribution
users actually do.

### `install-smoke-docker` — the container path
Builds the gem and `gem install`s it inside the official `fluent/fluentd:edge-debian`
image (via [`ci/install_smoke.sh`](ci/install_smoke.sh)), tracking the latest
Fluentd release to catch drift.

Both jobs install `build-essential default-libmysqlclient-dev` (the deps users
forget) and share the runtime load check in
[`ci/verify_plugins_load.rb`](ci/verify_plugins_load.rb).

## Why this shape
- Dropped `v1.16-debian`: it corresponds to the **EOL** fluent-package v5, so it
  was testing a dead distribution.
- Covering both the package path (fluent-package) and the container path (edge)
  matches how the plugin is actually deployed.

## Verification
Ran both paths locally:
- `fluent/fluentd:edge-debian` → mysql2 builds, plugins load.
- `fluent-package v6 LTS` on `ubuntu:24.04` → `/opt/fluent/bin/fluent-gem install`
  builds mysql2, `/opt/fluent/bin/ruby` loads the plugins.

Both print `input plugins loaded; mysql2 native extension OK`.

## Related issues
Backs the install guidance documented in #49 and provides regression coverage for
the install-failure cluster (#43, #16, #35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)