### PR TITLE
fix: guard delete detection against non-integer/large primary keys (#42)

### DIFF
--- a/lib/fluent/plugin/in_mysql_replicator.rb
+++ b/lib/fluent/plugin/in_mysql_replicator.rb
@@ -97,13 +97,7 @@ module Fluent::Plugin
         con.close
         ids = current_ids
         if @enable_delete
-          if current_ids.empty?
-            deleted_ids = Array.new
-          elsif previous_ids.empty?
-            deleted_ids = [*1...current_ids.max] - current_ids
-          else
-            deleted_ids = previous_ids - current_ids
-          end
+          deleted_ids = detect_deleted_ids(previous_ids, current_ids)
           if deleted_ids.count > 0
             hash_delete_by_list(table_hash, deleted_ids)
             deleted_ids.each do |id|
@@ -120,6 +114,19 @@ module Fluent::Plugin
 
     def hash_delete_by_list (hash, deleted_keys)
       deleted_keys.each{|k| hash.delete(k)}
+    end
+
+    # Returns the primary keys that disappeared since the previous poll.
+    #
+    # The first poll only establishes a baseline: there is no previous snapshot
+    # to diff against, so nothing is reported as deleted yet. This also avoids
+    # the old `[*1...current_ids.max]` range, which raised "bad value for range"
+    # for non-integer primary keys and allocated a huge array (and emitted
+    # phantom deletes) for large / sparse integer ids. (#42)
+    def detect_deleted_ids(previous_ids, current_ids)
+      return [] if previous_ids.empty?
+      return [] if current_ids.empty?
+      previous_ids - current_ids
     end
 
     def format_tag(tag, param)

--- a/test/plugin/test_in_mysql_replicator.rb
+++ b/test/plugin/test_in_mysql_replicator.rb
@@ -37,4 +37,39 @@ class MysqlReplicatorInputTest < Test::Unit::TestCase
     assert_equal 'input.mysql', d.instance.tag
     assert_equal false, d.instance.enable_delete
   end
+
+  # --- #42: delete detection must not build an integer Range from primary keys ---
+
+  def deleted_ids(previous_ids, current_ids)
+    conf = %[
+      tag   input.mysql
+      query SELECT id, text from search_test
+    ]
+    create_driver(conf).instance.detect_deleted_ids(previous_ids, current_ids)
+  end
+
+  def test_detect_deleted_ids_first_poll_reports_no_deletes
+    assert_equal [], deleted_ids([], [1, 2, 3])
+  end
+
+  def test_detect_deleted_ids_first_poll_with_string_keys_does_not_raise
+    # Regression for #42: the old `[*1...'c']` raised "bad value for range".
+    assert_nothing_raised do
+      assert_equal [], deleted_ids([], %w[a b c])
+    end
+  end
+
+  def test_detect_deleted_ids_first_poll_with_sparse_ids_has_no_phantom_deletes
+    # The old code returned `[*1...99] - [1, 50, 99]`, emitting deletes for ids
+    # that never existed. The first poll must only establish a baseline.
+    assert_equal [], deleted_ids([], [1, 50, 99])
+  end
+
+  def test_detect_deleted_ids_diffs_against_previous_snapshot
+    assert_equal [2], deleted_ids([1, 2, 3], [1, 3])
+  end
+
+  def test_detect_deleted_ids_empty_current_does_not_mass_delete
+    assert_equal [], deleted_ids([1, 2, 3], [])
+  end
 end


### PR DESCRIPTION
## Summary

Fixes the `mysql_replicator: failed to execute query / bad value for range` error reported in #42.

## Root cause

On the **first poll** (no previous snapshot yet), delete detection ran:

```ruby
deleted_ids = [*1...current_ids.max] - current_ids
```

This builds an integer `Range` from the primary-key values, which:
- raises **`bad value for range`** when the `primary_key` is non-integer (e.g. a UUID or string id) — exactly #42;
- for large ids, allocates a huge array (`[*1...10_000_000]`);
- emits **phantom delete events** for ids that never existed (every integer missing between `1` and `max`).

## Fix

Extract the logic into `detect_deleted_ids(previous_ids, current_ids)`:

```ruby
def detect_deleted_ids(previous_ids, current_ids)
  return [] if previous_ids.empty?   # first poll: baseline only
  return [] if current_ids.empty?    # don't mass-delete on an empty result
  previous_ids - current_ids
end
```

The first poll now only establishes a baseline (reports nothing deleted); deletions are detected on subsequent polls by diffing against the previous snapshot. All other behavior is unchanged.

## Tests

Added unit regression tests (no DB needed) covering:
- first poll with string keys → no `bad value for range`;
- first poll with sparse integer ids → no phantom deletes;
- normal delete diffed against the previous snapshot;
- emptied result set → no mass delete.

Verified locally on Ruby 3.4 (`6 tests, 11 assertions, 0 failures`).

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)