### PR TITLE
fix: only run nested sub-query for SELECT templates with ${...} (#4)

### DIFF
--- a/lib/fluent/plugin/in_mysql_replicator.rb
+++ b/lib/fluent/plugin/in_mysql_replicator.rb
@@ -71,7 +71,7 @@ module Fluent::Plugin
           current_ids << row[@primary_key]
           current_hash = Digest::SHA1.hexdigest(row.flatten.join)
           row.each {|k, v| row[k] = v.to_s if v.is_a?(Time) || v.is_a?(Date) || v.is_a?(BigDecimal)}
-          row.select {|k, v| v.to_s.strip.match(/^SELECT(\s+)/i) }.each do |k, v|
+          row.select {|k, v| nested_query_value?(v) }.each do |k, v|
             row[k] = [] unless row[k].is_a?(Array)
             nest_rows, prepared_con = query(v.gsub(/\$\{([^\}]+)\}/, row[$1].to_s), prepared_con)
             nest_rows.each do |nest_row|
@@ -135,6 +135,15 @@ module Fluent::Plugin
         log.warn "mysql_replicator: missing placeholder. :tag=>#{tag} :placeholder=>#{$1}" unless pattern.include?($1)
         pattern[$1]
       end
+    end
+
+    # A column value triggers a nested sub-query only when it is a query
+    # template containing a `${placeholder}` (e.g. "SELECT ... WHERE x = ${id}").
+    # Requiring the placeholder prevents ordinary text values that merely begin
+    # with the word "SELECT" from being executed as SQL. (#4; mirrors the fix
+    # already applied to mysql_replicator_multi in #6.)
+    def nested_query_value?(value)
+      value.to_s.strip.match?(/^SELECT[^\$]+\$\{[^\}]+\}/i)
     end
 
     def emit_record(tag, record)

--- a/test/plugin/test_in_mysql_replicator.rb
+++ b/test/plugin/test_in_mysql_replicator.rb
@@ -72,4 +72,36 @@ class MysqlReplicatorInputTest < Test::Unit::TestCase
   def test_detect_deleted_ids_empty_current_does_not_mass_delete
     assert_equal [], deleted_ids([1, 2, 3], [])
   end
+
+  # --- #4: a nested sub-query fires only for a SELECT template with ${...} ---
+
+  def nested?(value)
+    conf = %[
+      tag   input.mysql
+      query SELECT id, text from search_test
+    ]
+    create_driver(conf).instance.nested_query_value?(value)
+  end
+
+  def test_nested_query_value_true_for_select_with_placeholder
+    assert_true nested?("SELECT * FROM child WHERE parent_id = ${id}")
+  end
+
+  def test_nested_query_value_false_for_plain_text_starting_with_select
+    # Regression for #4: a data value beginning with "SELECT" must not run as SQL.
+    assert_false nested?("SELECT YOUR PLAN")
+  end
+
+  def test_nested_query_value_false_for_word_select
+    assert_false nested?("Selecting the best option")
+  end
+
+  def test_nested_query_value_false_for_select_without_placeholder
+    assert_false nested?("select count(*) from search_test")
+  end
+
+  def test_nested_query_value_false_for_non_string_values
+    assert_false nested?(12345)
+    assert_false nested?(nil)
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #4: in `mysql_replicator` (single), a column value that merely **begins with "SELECT"** triggered an unintended nested sub-query, so ordinary text data could be executed as SQL.

> 📌 **Stacked on #51** . Base is `fix/delete-detection-range` to keep the diff clean and avoid a conflict in the shared test file; GitHub will retarget this to `master` once #51 merges.

## Background — why #4 was still open

The maintainer proposed the correct fix back in 2014 and **#6 applied it — but only to `in_mysql_replicator_multi.rb`**:

| file | regex |
|------|-------|
| multi (`in_mysql_replicator_multi.rb`) | `/^SELECT[^\$]+\$\{[^\}]+\}/i` ✅ (fixed in #6) |
| single (`in_mysql_replicator.rb`) | `/^SELECT(\s+)/i` ❌ still fires without a placeholder |

#4 was reported against the **single** plugin, which never received the fix. This PR ports the proven `multi` regex to `single` so the two behave consistently.

## Fix

Require a `${placeholder}` before treating a value as a sub-query template, and extract the predicate for testing:

```ruby
def nested_query_value?(value)
  value.to_s.strip.match?(/^SELECT[^\$]+\$\{[^\}]+\}/i)
end
```

So `"SELECT * FROM child WHERE parent_id = ${id}"` still nests, while a data value like `"SELECT YOUR PLAN"` is left alone.

## Tests

Added regression tests: a real template (true), plain text starting with "SELECT", the word "Selecting", a SELECT without a placeholder, and non-string values (all false).

Verified locally on Ruby 3.4 (`11 tests, 17 assertions, 0 failures` — includes #51's tests since this is stacked).

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)