### PR TITLE
release: v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,90 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2026-06-16
+
+### Added
+- JSON column support for nested object indexing. The new opt-in `json_columns`
+  option parses MySQL `JSON` string columns into nested objects before they are
+  emitted, so Elasticsearch indexes them as real nested JSON instead of escaped
+  strings. Available on both `mysql_replicator` (config option) and
+  `mysql_replicator_multi` (new `json_columns` column on the `settings` table).
+  Malformed JSON and non-string values are left untouched. ([#48], implements [#18])
+
+### Fixed
+- Delete detection no longer raises `bad value for range` (and no longer
+  allocates a huge array or emits phantom delete events) when the `primary_key`
+  is non-integer (e.g. a UUID `CHAR(36)`) or a large/sparse integer. The first
+  poll now only establishes a baseline. ([#42])
+- In `mysql_replicator`, a nested sub-query is now triggered only when a column
+  value is an actual query template containing a `${placeholder}`. Previously any
+  value that merely began with the word `SELECT` was executed as SQL. This aligns
+  the single plugin with the fix already present in `mysql_replicator_multi`. ([#4])
+
+### Documentation
+- Document that the `mysql2` native extension requires the MySQL client
+  development headers (`default-libmysqlclient-dev` / `mysql-devel`), add a
+  "Failed to build gem native extension" troubleshooting note, and clarify that
+  change detection uses an in-memory hash of every row (not an `updated_at`
+  column). ([#43], [#40])
+
+### CI
+- Add install-smoke jobs that build and install the gem on **fluent-package v6
+  LTS** (the td-agent successor) and on the official `fluent/fluentd` image,
+  guarding against native-extension build regressions.
+
+## [1.1.0] - 2026-06-15
+
+### Added
+- Auto-detect the Elasticsearch version on first write and support Elasticsearch
+  6.x through 9.x. The `_type` field is omitted automatically for 7.x and later,
+  where mapping types were removed.
+- Dev Container configuration and end-to-end (E2E) replication tests, including
+  multi-table replication.
+
+### Changed
+- Migrated CI to GitHub Actions (removed Travis CI) and run the unit-test matrix
+  on Ruby 3.2–4.0, aligned with supported Fluentd versions.
+
+## [1.0.3] - 2024-02-28
+
+### Added
+- Reconnection option to recover from database connection errors. ([#45])
+
+## [1.0.2] - 2021-10-27
+
+### Fixed
+- Manage threads correctly in `mysql_replicator_multi`. ([#39])
+
+## [1.0.1] - 2019-11-19
+
+### Fixed
+- Ensure the nested-query database connection (`nest_db`) is always closed.
+
+### Documentation
+- Documentation updates.
+
+## [1.0.0] - 2019-11-13
+
+- First 1.0 release, targeting the Fluentd v0.14+ plugin API. Earlier 0.x
+  history is available in the git log.
+
+[1.2.0]: https://github.com/y-ken/fluent-plugin-mysql-replicator/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/y-ken/fluent-plugin-mysql-replicator/compare/v1.0.3...v1.1.0
+[1.0.3]: https://github.com/y-ken/fluent-plugin-mysql-replicator/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/y-ken/fluent-plugin-mysql-replicator/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/y-ken/fluent-plugin-mysql-replicator/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/y-ken/fluent-plugin-mysql-replicator/releases/tag/v1.0.0
+
+[#4]: https://github.com/y-ken/fluent-plugin-mysql-replicator/issues/4
+[#18]: https://github.com/y-ken/fluent-plugin-mysql-replicator/pull/18
+[#39]: https://github.com/y-ken/fluent-plugin-mysql-replicator/pull/39
+[#40]: https://github.com/y-ken/fluent-plugin-mysql-replicator/issues/40
+[#42]: https://github.com/y-ken/fluent-plugin-mysql-replicator/issues/42
+[#43]: https://github.com/y-ken/fluent-plugin-mysql-replicator/issues/43
+[#45]: https://github.com/y-ken/fluent-plugin-mysql-replicator/pull/45
+[#48]: https://github.com/y-ken/fluent-plugin-mysql-replicator/pull/48

--- a/fluent-plugin-mysql-replicator.gemspec
+++ b/fluent-plugin-mysql-replicator.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name        = "fluent-plugin-mysql-replicator"
-  s.version     = "1.1.0"
+  s.version     = "1.2.0"
   s.authors     = ["Kentaro Yoshida"]
   s.email       = ["y.ken.studio@gmail.com"]
   s.homepage    = "https://github.com/y-ken/fluent-plugin-mysql-replicator"


### PR DESCRIPTION
## Summary

Release **v1.2.0** (minor). Bumps `s.version` to `1.2.0` and introduces a
`CHANGELOG.md` that also backfills the 1.0.x / 1.1.0 history.

This consolidates everything merged since v1.1.0 into one release.

## What's in 1.2.0

### Added
- Opt-in **`json_columns`** support — parses MySQL `JSON` string columns into
  nested objects so Elasticsearch indexes real nested JSON (single + multi). (#48, implements #18)

### Fixed
- Delete detection no longer raises `bad value for range` / emits phantom deletes
  for non-integer (UUID `CHAR(36)`) or large primary keys. (#42)
- Nested sub-query in `mysql_replicator` now fires only for a `SELECT` template
  containing a `${...}` placeholder, not for any value beginning with "SELECT". (#4)

### Documentation / CI
- Native-extension install dependencies + troubleshooting; in-memory hash mechanism clarified. (#43, #40)
- Install-smoke CI on fluent-package v6 LTS and the official fluentd image.

## Versioning rationale

`json_columns` is a new, backward-compatible feature → **MINOR** bump (1.1.0 → 1.2.0).
The two fixes alone would have been a patch, but they ship together with the feature.

## Post-merge release steps (maintainer)

Publishing is a manual step. After merging this PR:

```bash
git checkout master && git pull
git tag v1.2.0
git push origin v1.2.0
gem build fluent-plugin-mysql-replicator.gemspec
gem push fluent-plugin-mysql-replicator-1.2.0.gem
```

(Optionally create a GitHub Release for the `v1.2.0` tag using the CHANGELOG entry.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)