### PR TITLE
feat: composite primary key support in mysql_replicator (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,28 @@ compatible.
 > event's own time, so date-rotated indices are best suited to insert-only data
 > (a record inserted on a previous day lives in that day's index).
 
+## Composite primary keys
+
+`primary_key` accepts a comma-separated list of columns, so tables keyed by more
+than one column are supported:
+
+```
+<source>
+  @type        mysql_replicator
+  # ...
+  query        SELECT tenant_id, id, name FROM items
+  primary_key  tenant_id,id
+</source>
+```
+
+Change detection (insert/update/delete) then keys on the combination of those
+columns, and the Elasticsearch document `_id` becomes their values joined by `,`
+(e.g. `10,7`). A single-column `primary_key` (the default `id`) behaves exactly
+as before.
+
+This applies to `mysql_replicator`; `mysql_replicator_multi` still expects a
+single-column primary key.
+
 ## Output example
 
 It is a example when detecting insert/update/delete events.

--- a/lib/fluent/plugin/in_mysql_replicator.rb
+++ b/lib/fluent/plugin/in_mysql_replicator.rb
@@ -17,7 +17,10 @@ module Fluent::Plugin
     config_param :encoding, :string, :default => 'utf8'
     config_param :query, :string
     config_param :prepared_query, :string, :default => nil
-    config_param :primary_key, :string, :default => 'id'
+    # A single column name, or a comma-separated list for a composite key
+    # (e.g. "tenant_id,id"). The id used for change detection and the
+    # Elasticsearch document _id is the combination of these columns.
+    config_param :primary_key, :array, :default => ['id']
     config_param :interval, :string, :default => '1m'
     config_param :enable_delete, :bool, :default => true
     # Comma-separated column names whose MySQL JSON values should be parsed into
@@ -73,7 +76,8 @@ module Fluent::Plugin
         end
         rows, con = query(@query, con)
         rows.each do |row|
-          current_ids << row[@primary_key]
+          id = extract_id(row)
+          current_ids << id
           current_hash = Digest::SHA1.hexdigest(row.flatten.join)
           row.each {|k, v| row[k] = v.to_s if v.is_a?(Time) || v.is_a?(Date) || v.is_a?(BigDecimal)}
           parse_json_columns!(row, @json_columns)
@@ -86,18 +90,18 @@ module Fluent::Plugin
             end
             prepared_con.close
           end
-          if row[@primary_key].nil?
-            log.error "mysql_replicator: missing primary_key. :tag=>#{tag} :primary_key=>#{primary_key}"
+          if id.any?(&:nil?)
+            log.error "mysql_replicator: missing primary_key. :tag=>#{tag} :primary_key=>#{@primary_key.join(',')} :id=>#{id}"
             break
           end
-          if !table_hash.include?(row[@primary_key])
+          if !table_hash.include?(id)
             tag = format_tag(@tag, {:event => :insert})
             emit_record(tag, row)
-          elsif table_hash[row[@primary_key]] != current_hash
+          elsif table_hash[id] != current_hash
             tag = format_tag(@tag, {:event => :update})
             emit_record(tag, row)
           end
-          table_hash[row[@primary_key]] = current_hash
+          table_hash[id] = current_hash
           rows_count += 1
         end
         con.close
@@ -108,7 +112,7 @@ module Fluent::Plugin
             hash_delete_by_list(table_hash, deleted_ids)
             deleted_ids.each do |id|
               tag = format_tag(@tag, {:event => :delete})
-              emit_record(tag, {@primary_key => id})
+              emit_record(tag, Hash[@primary_key.zip(id)])
             end
           end
         end
@@ -120,6 +124,12 @@ module Fluent::Plugin
 
     def hash_delete_by_list (hash, deleted_keys)
       deleted_keys.each{|k| hash.delete(k)}
+    end
+
+    # A row's id is the array of its primary-key column values, supporting
+    # composite keys. It is a single-element array for a single-column key.
+    def extract_id(row)
+      @primary_key.map {|col| row[col] }
     end
 
     # Returns the primary keys that disappeared since the previous poll.
@@ -152,7 +162,7 @@ module Fluent::Plugin
     end
 
     def format_tag(tag, param)
-      pattern = {'${event}' => param[:event].to_s, '${primary_key}' => @primary_key}
+      pattern = {'${event}' => param[:event].to_s, '${primary_key}' => @primary_key.join(',')}
       tag.gsub(/(\${[a-z_]+})/) do
         log.warn "mysql_replicator: missing placeholder. :tag=>#{tag} :placeholder=>#{$1}" unless pattern.include?($1)
         pattern[$1]

--- a/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
+++ b/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
@@ -68,18 +68,18 @@ class Fluent::Plugin::MysqlReplicatorElasticsearchOutput < Fluent::Plugin::Outpu
       tag_parts = tag.match(@tag_format)
       target_index = resolve_index_name(tag_parts['index_name'], time)
       target_type = tag_parts['type_name']
-      id_key = tag_parts['primary_key']
+      id_keys = tag_parts['primary_key'].to_s.split(',')
 
       if tag_parts['event'] == 'delete'
-        action = {"_index" => target_index, "_id" => record[id_key]}
+        action = {"_index" => target_index, "_id" => join_id(record, id_keys)}
         action['_type'] = target_type unless @suppress_type
         meta = { "delete" => action }
         bulk_message << Yajl::Encoder.encode(meta)
       else
         action = {"_index" => target_index}
         action['_type'] = target_type unless @suppress_type
-        if id_key && record[id_key]
-          action['_id'] = record[id_key]
+        if !id_keys.empty? && id_keys.all? {|k| !record[k].nil? }
+          action['_id'] = join_id(record, id_keys)
         end
         meta = { "index" => action }
         bulk_message << Yajl::Encoder.encode(meta)
@@ -103,6 +103,12 @@ class Fluent::Plugin::MysqlReplicatorElasticsearchOutput < Fluent::Plugin::Outpu
     http = Net::HTTP.new(@host, @port.to_i)
     http.use_ssl = @ssl
     http
+  end
+
+  # Build the document _id from one or more primary-key columns. A single key
+  # yields its value; a composite key yields the values joined by ",".
+  def join_id(record, id_keys)
+    id_keys.map {|k| record[k] }.join(',')
   end
 
   # Expand strftime tokens (e.g. "%Y%m%d") in the index name using the record's

--- a/test/plugin/test_in_mysql_replicator.rb
+++ b/test/plugin/test_in_mysql_replicator.rb
@@ -137,4 +137,30 @@ class MysqlReplicatorInputTest < Test::Unit::TestCase
     assert_false nested?(12345)
     assert_false nested?(nil)
   end
+
+  # --- #7: composite primary key support ---
+
+  def composite_driver
+    create_driver(%[
+      tag         input.mysql
+      query       SELECT tenant_id, id, text from t
+      primary_key tenant_id,id
+    ])
+  end
+
+  def test_primary_key_defaults_to_id_array
+    assert_equal ['id'], create_driver.instance.primary_key
+  end
+
+  def test_primary_key_parses_composite_list
+    assert_equal ['tenant_id', 'id'], composite_driver.instance.primary_key
+  end
+
+  def test_extract_id_single_key_is_one_element_array
+    assert_equal [7], create_driver.instance.extract_id({'id' => 7, 'text' => 'x'})
+  end
+
+  def test_extract_id_returns_composite_values
+    assert_equal [10, 7], composite_driver.instance.extract_id({'tenant_id' => 10, 'id' => 7, 'text' => 'x'})
+  end
 end

--- a/test/plugin/test_out_mysql_replicator_elasticsearch.rb
+++ b/test/plugin/test_out_mysql_replicator_elasticsearch.rb
@@ -79,6 +79,14 @@ class MysqlReplicatorElasticsearchOutput < Test::Unit::TestCase
     assert_equal('plainindex', index_cmds.first['index']['_index'])
   end
 
+  def test_composite_primary_key_builds_joined_id
+    stub_elastic
+    driver.run(default_tag: 'myindex.mytype.insert.tenant_id,id') do
+      driver.feed({'tenant_id' => 10, 'id' => 7, 'text' => 'x'})
+    end
+    assert_equal('10,7', index_cmds.first['index']['_id'])
+  end
+
   def test_writes_to_speficied_type
     driver.configure("type_name mytype\n")
     stub_elastic


### PR DESCRIPTION
## Summary

Implements composite primary key support for `mysql_replicator`, requested in #7.

`primary_key` now accepts a comma-separated list of columns:

```
<source>
  @type        mysql_replicator
  query        SELECT tenant_id, id, name FROM items
  primary_key  tenant_id,id
</source>
```

Change detection (insert/update/delete) then keys on the **combination** of
those columns, and the Elasticsearch document `_id` becomes their values joined
by `,` (e.g. `10,7`). A single-column `primary_key` (the default `id`) behaves
exactly as before.

## Changes

- **`in_mysql_replicator`**: `primary_key` parsed as an array; a row's id is
  `extract_id(row)` (the array of key-column values), used as the change-
  detection hash key; missing-key check covers every component; delete records
  are emitted as `{col => val}` for each key column.
- **`out_mysql_replicator_elasticsearch`**: builds the `_id` from one or more
  key columns via `join_id`. Backward compatible with single keys and with
  `mysql_replicator_multi` (which still uses a single-column key).
- README documents the feature.

## Relationship to #7

This reimplements the idea from **#7 (by @k4200)** on the current codebase
(which has diverged substantially since 2015) and **fixes a bug** in the
original: its update branch read `table_hash[row[id]]` (always `nil`) instead of
`table_hash[id]`. #7 can be closed as superseded by this PR.

## Tests

- input: `primary_key` defaults to `['id']`, parses `tenant_id,id`, and
  `extract_id` returns single/composite values.
- ES output: a composite-key tag produces a joined `_id` (`10,7`).

Verified locally on Ruby 3.4 (input `18 tests`, ES output `19 tests`, 0 failures).

Scope note: `mysql_replicator_multi` is unchanged (its integer-gap delete
detection assumes a single numeric key); composite support there could be a
follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)