### PR TITLE
release: v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-06-16
+
+### Added
+- Date-based Elasticsearch index names. If the index-name segment of the tag
+  contains `strftime` tokens (e.g. `%Y%m%d`), they are expanded using the
+  record's event time, enabling Logstash-style dated indices such as
+  `myindex-20180831`. Index names without a `%` are unchanged. ([#27])
+- Composite primary key support in `mysql_replicator`. `primary_key` now accepts
+  a comma-separated list of columns; the combination is used for change
+  detection and as the Elasticsearch document `_id` (values joined by `,`). A
+  single-column key behaves exactly as before. ([#7])
+
 ## [1.2.0] - 2026-06-16
 
 ### Added
@@ -73,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First 1.0 release, targeting the Fluentd v0.14+ plugin API. Earlier 0.x
   history is available in the git log.
 
+[1.3.0]: https://github.com/y-ken/fluent-plugin-mysql-replicator/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/y-ken/fluent-plugin-mysql-replicator/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/y-ken/fluent-plugin-mysql-replicator/compare/v1.0.3...v1.1.0
 [1.0.3]: https://github.com/y-ken/fluent-plugin-mysql-replicator/compare/v1.0.2...v1.0.3
@@ -81,7 +94,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.0]: https://github.com/y-ken/fluent-plugin-mysql-replicator/releases/tag/v1.0.0
 
 [#4]: https://github.com/y-ken/fluent-plugin-mysql-replicator/issues/4
+[#7]: https://github.com/y-ken/fluent-plugin-mysql-replicator/pull/7
 [#18]: https://github.com/y-ken/fluent-plugin-mysql-replicator/pull/18
+[#27]: https://github.com/y-ken/fluent-plugin-mysql-replicator/issues/27
 [#39]: https://github.com/y-ken/fluent-plugin-mysql-replicator/pull/39
 [#40]: https://github.com/y-ken/fluent-plugin-mysql-replicator/issues/40
 [#42]: https://github.com/y-ken/fluent-plugin-mysql-replicator/issues/42

--- a/fluent-plugin-mysql-replicator.gemspec
+++ b/fluent-plugin-mysql-replicator.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name        = "fluent-plugin-mysql-replicator"
-  s.version     = "1.2.0"
+  s.version     = "1.3.0"
   s.authors     = ["Kentaro Yoshida"]
   s.email       = ["y.ken.studio@gmail.com"]
   s.homepage    = "https://github.com/y-ken/fluent-plugin-mysql-replicator"


### PR DESCRIPTION
## Summary

Release **v1.3.0** (minor). Bumps `s.version` to `1.3.0` and adds the CHANGELOG entry.

Consolidates the two backward-compatible features merged since v1.2.0.

## What's in 1.3.0

### Added
- **Date-based Elasticsearch index names** — strftime tokens (e.g. `%Y%m%d`) in
  the tag's index-name segment are expanded using the record's event time,
  enabling Logstash-style dated indices like `myindex-20180831`. (#27, #54)
- **Composite primary keys** in `mysql_replicator` — `primary_key` accepts a
  comma-separated list of columns, used for change detection and as the
  Elasticsearch document `_id`. Single-column keys are unchanged. (#7, #55)

## Versioning rationale

Both changes are new, backward-compatible features → **MINOR** bump (1.2.0 → 1.3.0).
(The plugin-managed index template feature is intentionally **not** in this
release; it will land separately because it raises the minimum Elasticsearch
version.)

## Post-merge release steps (maintainer)

```bash
git checkout master && git pull
git tag v1.3.0
git push origin v1.3.0
gem build fluent-plugin-mysql-replicator.gemspec
gem push fluent-plugin-mysql-replicator-1.3.0.gem
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)