### PR TITLE
feat: plugin-managed Elasticsearch index templates (#20, #36 geo_point)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,52 @@ as before.
 This applies to `mysql_replicator`; `mysql_replicator_multi` still expects a
 single-column primary key.
 
+## Index templates (mappings)
+
+By default Elasticsearch infers field types from the first document (dynamic
+mapping), and an existing field's mapping cannot be changed afterwards. To
+control a field's mapping — e.g. `keyword` for a non-analyzed field, or
+`geo_point`, which dynamic mapping never infers — install an **index template**
+so it is applied to indices *before* the first document is written.
+
+`mysql_replicator_elasticsearch` can install a template on startup. The option
+names and defaults mirror `fluent-plugin-elasticsearch`:
+
+```
+<match replicator.**>
+  @type mysql_replicator_elasticsearch
+  # ...
+  template_name        myindex_template
+  template_file        /etc/fluent/myindex_template.json
+  template_overwrite   false   # set true to replace an existing template
+  use_legacy_template  true    # true: PUT /_template (ES 6.x+); false: PUT /_index_template (ES >= 7.8)
+</match>
+```
+
+`template_name` and `template_file` must be set together. The template is a
+**server-side rule**, so once installed it is applied automatically to every new
+index whose name matches its `index_patterns` — **including future date-rolled
+indices** (see *Date-based index names* above) — with no per-write work.
+
+Example `template_file` (legacy format, the default) mapping a non-analyzed
+field as `keyword` and a coordinate field as `geo_point`:
+
+```json
+{
+  "index_patterns": ["myindex-*"],
+  "mappings": {
+    "properties": {
+      "message":  { "type": "keyword" },
+      "location": { "type": "geo_point" }
+    }
+  }
+}
+```
+
+With `use_legacy_template false`, use the composable template format instead
+(wrap `settings`/`mappings` under a `template` object); this requires
+Elasticsearch 7.8 or later.
+
 ## Output example
 
 It is a example when detecting insert/update/delete events.

--- a/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
+++ b/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
@@ -17,6 +17,19 @@ class Fluent::Plugin::MysqlReplicatorElasticsearchOutput < Fluent::Plugin::Outpu
   config_param :username, :string, :default => nil
   config_param :password, :string, :default => nil, :secret => true
 
+  # Optional: install an Elasticsearch index template on startup so that newly
+  # created indices (including future date-rolled ones) get the desired mapping
+  # (e.g. geo_point or keyword fields) before the first document locks in
+  # dynamic mapping. template_name and template_file must be set together.
+  #
+  # Parameter names and defaults mirror fluent-plugin-elasticsearch:
+  #   use_legacy_template true  (default) -> PUT /_template/<name>        (ES 6.x+)
+  #   use_legacy_template false           -> PUT /_index_template/<name>  (ES >= 7.8)
+  config_param :template_name, :string, :default => nil
+  config_param :template_file, :string, :default => nil
+  config_param :template_overwrite, :bool, :default => false
+  config_param :use_legacy_template, :bool, :default => true
+
   config_section :buffer do
     config_set_default :@type, DEFAULT_BUFFER_TYPE
   end
@@ -35,12 +48,21 @@ class Fluent::Plugin::MysqlReplicatorElasticsearchOutput < Fluent::Plugin::Outpu
     else
       @tag_format = Regexp.new(conf['tag_format'])
     end
+
+    if @template_name.nil? != @template_file.nil?
+      raise Fluent::ConfigError, "mysql_replicator_elasticsearch: 'template_name' and 'template_file' must be set together"
+    end
+    if @template_file && !File.exist?(@template_file)
+      raise Fluent::ConfigError, "mysql_replicator_elasticsearch: template_file not found: #{@template_file}"
+    end
   end
 
   def start
     super
     # nil means "not yet detected"; resolved on the first write.
     @suppress_type = nil
+    @es_version = nil
+    @template_installed = false
   end
 
   def format(tag, time, record)
@@ -61,6 +83,7 @@ class Fluent::Plugin::MysqlReplicatorElasticsearchOutput < Fluent::Plugin::Outpu
 
   def write(chunk)
     detect_type_suppression if @suppress_type.nil?
+    install_template_once if @template_name
 
     bulk_message = []
 
@@ -123,25 +146,76 @@ class Fluent::Plugin::MysqlReplicatorElasticsearchOutput < Fluent::Plugin::Outpu
   end
 
   # Mapping types were removed in Elasticsearch 8.x and deprecated in 7.x.
-  # Detect the major version once and omit "_type" for 7.x and later.
+  # Detect the version once and omit "_type" for 7.x and later.
   def detect_type_suppression
-    major = elasticsearch_major_version
+    @es_version = elasticsearch_version
+    major = @es_version&.first
     @suppress_type = !major.nil? && major >= 7
     if major
-      log.info "mysql_replicator_elasticsearch: detected Elasticsearch #{major}.x, suppress_type=#{@suppress_type}"
+      log.info "mysql_replicator_elasticsearch: detected Elasticsearch #{@es_version.join('.')}, suppress_type=#{@suppress_type}"
     else
       log.warn "mysql_replicator_elasticsearch: could not detect Elasticsearch version, sending '_type' (assuming 6.x)"
     end
   end
 
-  def elasticsearch_major_version
+  # Returns the Elasticsearch version as [major, minor], or nil if undetectable.
+  def elasticsearch_version
     request = Net::HTTP::Get.new('/')
     request.basic_auth(@username, @password) if @username && @password
     response = new_http.request(request)
     number = Yajl::Parser.parse(response.body).dig('version', 'number')
-    number.to_s.split('.').first.to_i
+    return nil if number.nil?
+    number.to_s.split('.').first(2).map(&:to_i)
   rescue => e
     log.warn "mysql_replicator_elasticsearch: version detection failed: #{e.message}"
     nil
+  end
+
+  # Install the configured index template once, on the first write. The template
+  # is a server-side rule, so Elasticsearch applies it to every new index whose
+  # name matches its index_patterns -- including future date-rolled indices --
+  # without any further action here. Failures are logged but never abort indexing.
+  def install_template_once
+    return if @template_installed
+    @template_installed = true
+    install_template
+  rescue => e
+    log.warn "mysql_replicator_elasticsearch: failed to install index template '#{@template_name}': #{e.message}"
+  end
+
+  def install_template
+    if !@use_legacy_template && !composable_templates_supported?
+      log.warn "mysql_replicator_elasticsearch: composable index templates require Elasticsearch >= 7.8; skipping template '#{@template_name}' (detected #{@es_version&.join('.') || 'unknown'})"
+      return
+    end
+    if !@template_overwrite && template_exists?
+      log.info "mysql_replicator_elasticsearch: index template '#{@template_name}' already exists; skipping (set 'template_overwrite true' to replace)"
+      return
+    end
+    put_template(File.read(@template_file))
+    log.info "mysql_replicator_elasticsearch: installed index template '#{@template_name}' (#{@use_legacy_template ? 'legacy' : 'composable'})"
+  end
+
+  def composable_templates_supported?
+    return false if @es_version.nil?
+    major, minor = @es_version
+    major > 7 || (major == 7 && minor >= 8)
+  end
+
+  def template_path
+    @use_legacy_template ? "/_template/#{@template_name}" : "/_index_template/#{@template_name}"
+  end
+
+  def template_exists?
+    request = Net::HTTP::Get.new(template_path)
+    request.basic_auth(@username, @password) if @username && @password
+    new_http.request(request).code.to_i == 200
+  end
+
+  def put_template(body)
+    request = Net::HTTP::Put.new(template_path, {'content-type' => 'application/json; charset=utf-8'})
+    request.basic_auth(@username, @password) if @username && @password
+    request.body = body
+    new_http.request(request).value
   end
 end

--- a/test/plugin/test_out_mysql_replicator_elasticsearch.rb
+++ b/test/plugin/test_out_mysql_replicator_elasticsearch.rb
@@ -1,6 +1,7 @@
 require 'helper'
 require 'fluent/test/driver/output'
 require 'webmock/test_unit'
+require 'tempfile'
 
 WebMock.disable_net_connect!
 
@@ -11,6 +12,19 @@ class MysqlReplicatorElasticsearchOutput < Test::Unit::TestCase
     Fluent::Test.setup
     @driver = nil
     @tag = 'myindex.mytype.insert.id'
+  end
+
+  def teardown
+    WebMock.reset!
+    (@tmpfiles || []).each {|f| f.close! rescue nil }
+  end
+
+  def write_template_file(body = '{"index_patterns":["myindex-*"],"mappings":{"properties":{"loc":{"type":"geo_point"}}}}')
+    file = Tempfile.new(['tmpl', '.json'])
+    file.write(body)
+    file.flush
+    (@tmpfiles ||= []) << file
+    file.path
   end
 
   def driver(conf='')
@@ -185,6 +199,48 @@ class MysqlReplicatorElasticsearchOutput < Test::Unit::TestCase
         driver.feed(sample_record)
       end
     }
+  end
+
+  def test_installs_legacy_template_by_default
+    stub_elastic # version 6.8.23
+    stub_request(:get, "http://localhost:9200/_template/my_tmpl").to_return(:status => 404)
+    put_tmpl = stub_request(:put, "http://localhost:9200/_template/my_tmpl").to_return(:status => 200, :body => "{}")
+    driver.configure("template_name my_tmpl\ntemplate_file #{write_template_file}\n")
+    driver.run(default_tag: @tag) { driver.feed(sample_record) }
+    assert_requested(put_tmpl)
+  end
+
+  def test_installs_composable_template_when_legacy_disabled
+    stub_elastic
+    stub_elastic_version("http://localhost:9200/", "8.18.0")
+    stub_request(:get, "http://localhost:9200/_index_template/my_tmpl").to_return(:status => 404)
+    put_tmpl = stub_request(:put, "http://localhost:9200/_index_template/my_tmpl").to_return(:status => 200, :body => "{}")
+    driver.configure("template_name my_tmpl\ntemplate_file #{write_template_file}\nuse_legacy_template false\n")
+    driver.run(default_tag: @tag) { driver.feed(sample_record) }
+    assert_requested(put_tmpl)
+  end
+
+  def test_skips_composable_template_on_old_elasticsearch
+    stub_elastic # version 6.8.23 (< 7.8)
+    put_tmpl = stub_request(:put, "http://localhost:9200/_index_template/my_tmpl")
+    driver.configure("template_name my_tmpl\ntemplate_file #{write_template_file}\nuse_legacy_template false\n")
+    driver.run(default_tag: @tag) { driver.feed(sample_record) }
+    assert_not_requested(put_tmpl)
+  end
+
+  def test_skips_template_when_it_exists_and_no_overwrite
+    stub_elastic
+    stub_request(:get, "http://localhost:9200/_template/my_tmpl").to_return(:status => 200, :body => "{}")
+    put_tmpl = stub_request(:put, "http://localhost:9200/_template/my_tmpl")
+    driver.configure("template_name my_tmpl\ntemplate_file #{write_template_file}\n")
+    driver.run(default_tag: @tag) { driver.feed(sample_record) }
+    assert_not_requested(put_tmpl)
+  end
+
+  def test_template_name_without_file_raises
+    assert_raise(Fluent::ConfigError) do
+      driver.configure("template_name my_tmpl\n")
+    end
   end
 
   def test_writes_to_https_host


### PR DESCRIPTION
## Summary

Lets `mysql_replicator_elasticsearch` install an **index template** on startup so newly created indices get the desired mapping
*before* the first document locks in dynamic mapping.

This unblocks the mapping-dependent requests that value coercion can't reach:
- **keyword / `not_analyzed`** fields (#20)
- **`geo_point`** (#36) — dynamic mapping never infers it

## Config (mirrors fluent-plugin-elasticsearch)

```
template_name        myindex_template
template_file        /etc/fluent/myindex_template.json
template_overwrite   false
use_legacy_template  true   # true: PUT /_template (ES 6.x+); false: PUT /_index_template (ES >= 7.8)
```

`template_name` + `template_file` must be set together. Option **names, defaults,
and template-file formats match fluent-plugin-elasticsearch**, so existing
templates/knowledge carry over.

## Why this is the right mechanism for date-based indices

The template is a **server-side rule**: once installed, Elasticsearch applies it
to *every* new index matching `index_patterns`, including the **next day's
date-rolled index** (from #54) — no per-write or per-day action needed. This is
exactly why a template (not per-index creation) is used.

## Behavior / safety

- Installed once on the first write (after version detection); failures are
  **logged but never abort indexing**.
- Composable templates (`use_legacy_template false`) require ES ≥ 7.8; on older
  ES it is skipped with a warning. The default legacy path works on ES 6.x+, so
  **this is an opt-in, backward-compatible addition** (no change to core
  indexing or the supported ES range) → next release is a **minor** (v1.4.0).

## Example template_file (legacy format, default)

```json
{
  "index_patterns": ["myindex-*"],
  "mappings": { "properties": {
    "message":  { "type": "keyword" },
    "location": { "type": "geo_point" }
  } }
}
```

## Tests

5 new unit tests (WebMock): legacy install (default), composable install
(`use_legacy_template false` + ES 8.x), skip on ES < 7.8, skip when the template
exists and `template_overwrite false`, and the must-be-set-together config error.
Verified locally on Ruby 3.4 (`24 tests, 0 failures`).

## Follow-ups
- After merge: comment on / close #20 (keyword via template now documented); on
  #36, the `geo_point` half is covered here, the `decimal→numeric` half remains
  (value coercion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)