### PR TITLE
chore: composable index template default + document DECIMAL mapping (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ control a field's mapping — e.g. `keyword` for a non-analyzed field, or
 so it is applied to indices *before* the first document is written.
 
 `mysql_replicator_elasticsearch` can install a template on startup. The option
-names and defaults mirror `fluent-plugin-elasticsearch`:
+names mirror `fluent-plugin-elasticsearch` (the default here uses the modern
+composable API, whereas fluent-plugin-elasticsearch defaults to legacy):
 
 ```
 <match replicator.**>
@@ -187,7 +188,7 @@ names and defaults mirror `fluent-plugin-elasticsearch`:
   template_name        myindex_template
   template_file        /etc/fluent/myindex_template.json
   template_overwrite   false   # set true to replace an existing template
-  use_legacy_template  true    # true: PUT /_template (ES 6.x+); false: PUT /_index_template (ES >= 7.8)
+  use_legacy_template  false   # default. false: PUT /_index_template (ES >= 7.8); true: PUT /_template (legacy, ES 6.x+)
 </match>
 ```
 
@@ -196,24 +197,41 @@ names and defaults mirror `fluent-plugin-elasticsearch`:
 index whose name matches its `index_patterns` — **including future date-rolled
 indices** (see *Date-based index names* above) — with no per-write work.
 
-Example `template_file` (legacy format, the default) mapping a non-analyzed
-field as `keyword` and a coordinate field as `geo_point`:
+Example `template_file` (composable format, the default) mapping a non-analyzed
+field as `keyword`, a coordinate field as `geo_point`, and a `DECIMAL` column as
+a numeric (see below):
 
 ```json
 {
   "index_patterns": ["myindex-*"],
-  "mappings": {
-    "properties": {
-      "message":  { "type": "keyword" },
-      "location": { "type": "geo_point" }
+  "template": {
+    "mappings": {
+      "properties": {
+        "message":  { "type": "keyword" },
+        "location": { "type": "geo_point" },
+        "price":    { "type": "scaled_float", "scaling_factor": 100 }
+      }
     }
   }
 }
 ```
 
-With `use_legacy_template false`, use the composable template format instead
-(wrap `settings`/`mappings` under a `template` object); this requires
-Elasticsearch 7.8 or later.
+For Elasticsearch 6.x — or to reuse an existing `fluent-plugin-elasticsearch`
+legacy template — set `use_legacy_template true` and put `settings`/`mappings`
+at the top level (not under `template`).
+
+### Numeric columns (DECIMAL)
+
+MySQL `DECIMAL` columns are sent to Elasticsearch **as strings** — not because of
+a type-inference issue, but because `BigDecimal` cannot cross Fluentd's msgpack
+buffer between the input and output plugins, so the value is stringified (which
+also preserves its exact precision). Under the default dynamic mapping such a
+field is therefore indexed as text.
+
+To index it as a number, map the field in your template as `double`, or — to keep
+exact fixed-point precision — `scaled_float` (as `price` above). Elasticsearch's
+`coerce` (enabled by default for numeric types) converts the numeric string to a
+number at index time, so no value conversion is needed in the plugin.
 
 ## Output example
 

--- a/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
+++ b/lib/fluent/plugin/out_mysql_replicator_elasticsearch.rb
@@ -22,13 +22,14 @@ class Fluent::Plugin::MysqlReplicatorElasticsearchOutput < Fluent::Plugin::Outpu
   # (e.g. geo_point or keyword fields) before the first document locks in
   # dynamic mapping. template_name and template_file must be set together.
   #
-  # Parameter names and defaults mirror fluent-plugin-elasticsearch:
-  #   use_legacy_template true  (default) -> PUT /_template/<name>        (ES 6.x+)
-  #   use_legacy_template false           -> PUT /_index_template/<name>  (ES >= 7.8)
+  # Parameter names mirror fluent-plugin-elasticsearch. The default uses the
+  # modern composable API (fluent-plugin-elasticsearch defaults to legacy):
+  #   use_legacy_template false (default) -> PUT /_index_template/<name>  (composable, ES >= 7.8)
+  #   use_legacy_template true            -> PUT /_template/<name>        (legacy, ES 6.x+)
   config_param :template_name, :string, :default => nil
   config_param :template_file, :string, :default => nil
   config_param :template_overwrite, :bool, :default => false
-  config_param :use_legacy_template, :bool, :default => true
+  config_param :use_legacy_template, :bool, :default => false
 
   config_section :buffer do
     config_set_default :@type, DEFAULT_BUFFER_TYPE
@@ -185,7 +186,7 @@ class Fluent::Plugin::MysqlReplicatorElasticsearchOutput < Fluent::Plugin::Outpu
 
   def install_template
     if !@use_legacy_template && !composable_templates_supported?
-      log.warn "mysql_replicator_elasticsearch: composable index templates require Elasticsearch >= 7.8; skipping template '#{@template_name}' (detected #{@es_version&.join('.') || 'unknown'})"
+      log.warn "mysql_replicator_elasticsearch: composable index templates require Elasticsearch >= 7.8; skipping template '#{@template_name}' (detected #{@es_version&.join('.') || 'unknown'}). Set 'use_legacy_template true' for older Elasticsearch."
       return
     end
     if !@template_overwrite && template_exists?

--- a/test/plugin/test_out_mysql_replicator_elasticsearch.rb
+++ b/test/plugin/test_out_mysql_replicator_elasticsearch.rb
@@ -201,37 +201,38 @@ class MysqlReplicatorElasticsearchOutput < Test::Unit::TestCase
     }
   end
 
-  def test_installs_legacy_template_by_default
-    stub_elastic # version 6.8.23
-    stub_request(:get, "http://localhost:9200/_template/my_tmpl").to_return(:status => 404)
-    put_tmpl = stub_request(:put, "http://localhost:9200/_template/my_tmpl").to_return(:status => 200, :body => "{}")
+  def test_installs_composable_template_by_default
+    stub_elastic
+    stub_elastic_version("http://localhost:9200/", "8.18.0")
+    stub_request(:get, "http://localhost:9200/_index_template/my_tmpl").to_return(:status => 404)
+    put_tmpl = stub_request(:put, "http://localhost:9200/_index_template/my_tmpl").to_return(:status => 200, :body => "{}")
     driver.configure("template_name my_tmpl\ntemplate_file #{write_template_file}\n")
     driver.run(default_tag: @tag) { driver.feed(sample_record) }
     assert_requested(put_tmpl)
   end
 
-  def test_installs_composable_template_when_legacy_disabled
-    stub_elastic
-    stub_elastic_version("http://localhost:9200/", "8.18.0")
-    stub_request(:get, "http://localhost:9200/_index_template/my_tmpl").to_return(:status => 404)
-    put_tmpl = stub_request(:put, "http://localhost:9200/_index_template/my_tmpl").to_return(:status => 200, :body => "{}")
-    driver.configure("template_name my_tmpl\ntemplate_file #{write_template_file}\nuse_legacy_template false\n")
+  def test_installs_legacy_template_when_enabled
+    stub_elastic # version 6.8.23
+    stub_request(:get, "http://localhost:9200/_template/my_tmpl").to_return(:status => 404)
+    put_tmpl = stub_request(:put, "http://localhost:9200/_template/my_tmpl").to_return(:status => 200, :body => "{}")
+    driver.configure("template_name my_tmpl\ntemplate_file #{write_template_file}\nuse_legacy_template true\n")
     driver.run(default_tag: @tag) { driver.feed(sample_record) }
     assert_requested(put_tmpl)
   end
 
   def test_skips_composable_template_on_old_elasticsearch
-    stub_elastic # version 6.8.23 (< 7.8)
+    stub_elastic # version 6.8.23 (< 7.8), default composable
     put_tmpl = stub_request(:put, "http://localhost:9200/_index_template/my_tmpl")
-    driver.configure("template_name my_tmpl\ntemplate_file #{write_template_file}\nuse_legacy_template false\n")
+    driver.configure("template_name my_tmpl\ntemplate_file #{write_template_file}\n")
     driver.run(default_tag: @tag) { driver.feed(sample_record) }
     assert_not_requested(put_tmpl)
   end
 
   def test_skips_template_when_it_exists_and_no_overwrite
     stub_elastic
-    stub_request(:get, "http://localhost:9200/_template/my_tmpl").to_return(:status => 200, :body => "{}")
-    put_tmpl = stub_request(:put, "http://localhost:9200/_template/my_tmpl")
+    stub_elastic_version("http://localhost:9200/", "8.18.0")
+    stub_request(:get, "http://localhost:9200/_index_template/my_tmpl").to_return(:status => 200, :body => "{}")
+    put_tmpl = stub_request(:put, "http://localhost:9200/_index_template/my_tmpl")
     driver.configure("template_name my_tmpl\ntemplate_file #{write_template_file}\n")
     driver.run(default_tag: @tag) { driver.feed(sample_record) }
     assert_not_requested(put_tmpl)


### PR DESCRIPTION
## Summary

Two small, related follow-ups to the index-template feature (#57, still unreleased):

### 1. Default `use_legacy_template` to `false` (composable)

New users starting today should get the modern **composable `_index_template`**
API (ES ≥ 7.8) rather than the deprecated legacy `_template`. Since #57 is not
yet released, no shipped version is affected by the default change.

- `use_legacy_template false` (default) → `PUT /_index_template` (ES ≥ 7.8)
- `use_legacy_template true` → `PUT /_template` (legacy, ES 6.x+)

The "skipped on ES < 7.8" warning now tells the user to set
`use_legacy_template true` for older Elasticsearch. (Param names still mirror
fluent-plugin-elasticsearch; only the default differs.)

### 2. Document DECIMAL → numeric mapping (#36)

Answers "why is decimal sent as text?": **not** a type-inference issue — it's
that `BigDecimal` can't cross Fluentd's msgpack buffer (the original #3 fix), so
it is stringified (which also preserves exact precision). The README now explains
that to index decimals as numbers you map the field as `double`/`scaled_float` in
a template, and **Elasticsearch's `coerce` converts the numeric string at index
time** — so no value conversion (and no precision loss) is needed in the plugin.

This resolves the remaining half of #36 (the `geo_point` half was handled by #57).

## Tests

Reworked the template unit tests for the new default (composable install by
default; legacy install when explicitly enabled; skip on ES < 7.8; skip when the
template exists). `24 tests, 0 failures` locally on Ruby 3.4.

## Follow-up
- #36 can be closed (both `geo_point` and `decimal` are now addressed via index templates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)