### PR TITLE
release: v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-06-17
+
+### Added
+- Plugin-managed Elasticsearch index templates. New `template_name`,
+  `template_file`, `template_overwrite`, and `use_legacy_template` options on
+  `mysql_replicator_elasticsearch` install an index template on startup, so newly
+  created indices — including future date-rolled ones — get the desired mapping
+  before the first document locks in dynamic mapping. This enables mappings that
+  cannot be changed after the fact: `keyword` / non-analyzed fields ([#20]) and
+  `geo_point` ([#36]). `use_legacy_template` defaults to `false` (composable
+  `PUT /_index_template`, Elasticsearch >= 7.8); set it to `true` for the legacy
+  `PUT /_template` API (Elasticsearch 6.x+).
+
+### Documentation
+- Document that MySQL `DECIMAL` columns are emitted as strings (because
+  `BigDecimal` cannot cross Fluentd's msgpack buffer, which also preserves exact
+  precision) and should be mapped as `double` or `scaled_float` in an index
+  template, where Elasticsearch coerces the numeric string at index time. ([#36])
+
 ## [1.3.0] - 2026-06-16
 
 ### Added
@@ -85,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First 1.0 release, targeting the Fluentd v0.14+ plugin API. Earlier 0.x
   history is available in the git log.
 
+[1.4.0]: https://github.com/y-ken/fluent-plugin-mysql-replicator/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/y-ken/fluent-plugin-mysql-replicator/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/y-ken/fluent-plugin-mysql-replicator/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/y-ken/fluent-plugin-mysql-replicator/compare/v1.0.3...v1.1.0
@@ -96,7 +116,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#4]: https://github.com/y-ken/fluent-plugin-mysql-replicator/issues/4
 [#7]: https://github.com/y-ken/fluent-plugin-mysql-replicator/pull/7
 [#18]: https://github.com/y-ken/fluent-plugin-mysql-replicator/pull/18
+[#20]: https://github.com/y-ken/fluent-plugin-mysql-replicator/issues/20
 [#27]: https://github.com/y-ken/fluent-plugin-mysql-replicator/issues/27
+[#36]: https://github.com/y-ken/fluent-plugin-mysql-replicator/issues/36
 [#39]: https://github.com/y-ken/fluent-plugin-mysql-replicator/pull/39
 [#40]: https://github.com/y-ken/fluent-plugin-mysql-replicator/issues/40
 [#42]: https://github.com/y-ken/fluent-plugin-mysql-replicator/issues/42

--- a/fluent-plugin-mysql-replicator.gemspec
+++ b/fluent-plugin-mysql-replicator.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name        = "fluent-plugin-mysql-replicator"
-  s.version     = "1.3.0"
+  s.version     = "1.4.0"
   s.authors     = ["Kentaro Yoshida"]
   s.email       = ["y.ken.studio@gmail.com"]
   s.homepage    = "https://github.com/y-ken/fluent-plugin-mysql-replicator"


### PR DESCRIPTION
## Summary

Release **v1.4.0** (minor). Bumps `s.version` to `1.4.0` and adds the CHANGELOG entry.

Consolidates everything merged since v1.3.0.

## What's in 1.4.0

### Added
- **Plugin-managed Elasticsearch index templates** — `template_name`,
  `template_file`, `template_overwrite`, `use_legacy_template` on
  `mysql_replicator_elasticsearch` install a template on startup so newly created
  indices (including date-rolled ones) get the desired mapping before the first
  document. Enables mappings dynamic mapping can't fix afterwards: `keyword` (#20)
  and `geo_point` (#36). Default is composable `_index_template` (ES ≥ 7.8);
  `use_legacy_template true` uses legacy `_template` (ES 6.x+). (#57, #58)

### Documentation
- DECIMAL columns are sent as strings (BigDecimal can't cross the msgpack buffer;
  this also preserves precision) → map them as `double`/`scaled_float` in a
  template and Elasticsearch coerces at index time. (#36, #58)

## Versioning rationale

The index-template feature is opt-in and does not change core indexing or the
supported Elasticsearch range, so this is a backward-compatible **MINOR** bump
(1.3.0 → 1.4.0).

## Post-merge release steps (maintainer)

```bash
git checkout master && git pull
git tag v1.4.0
git push origin v1.4.0
gem build fluent-plugin-mysql-replicator.gemspec
gem push fluent-plugin-mysql-replicator-1.4.0.gem
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)