### PR TITLE
docs: modernize README and tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,21 @@
 
 ## Overview
 
-Fluentd input plugin to track insert/update/delete event from MySQL database server.  
-Not only that, it could multiple table replication into single or multi Elasticsearch/Solr.  
-It's comming support replicate to another RDB/noSQL.
+Fluentd input plugin that tracks insert / update / delete events on a MySQL
+database server, and can replicate one or many tables into Elasticsearch or Solr.
 
 ## Requirements
 
-| fluent-plugin-mysql-replicator | fluentd    | ruby   |
-|--------------------|------------|--------|
-|  >= 0.6.1          | >= v0.14.x | >= 2.1 |
-|  <= 0.6.1          | >= v0.12.x | >= 1.9 |
+The current release is tested against:
+
+| Component              | Versions |
+|------------------------|----------|
+| Ruby                   | 3.2, 3.3, 3.4, 4.0 |
+| Fluentd                | v1.x, including [fluent-package](https://www.fluentd.org/download/fluent_package) v6 LTS (bundles Fluentd 1.19) |
+| Elasticsearch (output) | 6.x – 9.x |
+
+Older 0.6.x / 1.0.x releases ran on Fluentd v0.12 / v0.14 and Ruby >= 2.1, with
+td-agent (now end-of-life) as the packaged distribution.
 
 ## Dependency
 
@@ -41,18 +46,18 @@ $ apt-get update && apt-get install -y build-essential default-libmysqlclient-de
 
 ## Installation
 
-install with gem or fluent-gem command as:
+Install with RubyGems, or with `fluent-gem` for fluent-package:
 
-`````
-# for system installed fluentd
-$ gem install fluent-plugin-mysql-replicator -v 1.0.3
+```bash
+# system-wide Fluentd (RubyGems)
+$ gem install fluent-plugin-mysql-replicator
 
-# for td-agent2
-$ sudo td-agent-gem install fluent-plugin-mysql-replicator -v 0.6.1
+# fluent-package (the td-agent successor)
+$ sudo fluent-gem install fluent-plugin-mysql-replicator
+```
 
-# for td-agent3
-$ sudo td-agent-gem install fluent-plugin-mysql-replicator -v 1.0.3
-`````
+If the `mysql2` native extension fails to build, see the **Dependency** section
+above.
 
 ## Development container
 
@@ -63,7 +68,8 @@ The container installs Ruby, Bundler, and required native build dependencies.
 After opening the repository in the Dev Container, run:
 
 ```
-bundle install --path vendor/bundle
+bundle config set --local path vendor/bundle
+bundle install
 ```
 
 Then run tests like:
@@ -169,6 +175,26 @@ as before.
 This applies to `mysql_replicator`; `mysql_replicator_multi` still expects a
 single-column primary key.
 
+## Nested documents
+
+You can nest the rows of a sub-query under a column. Select a SQL query template
+(containing a `${placeholder}`) as a column value; for each row the plugin runs
+that query, substituting the placeholder with the row's column value, and nests
+the results under the column:
+
+```sql
+SELECT
+  id,
+  title,
+  'SELECT body, author FROM comments WHERE post_id = ${id}' AS comments
+FROM posts;
+```
+
+Here every `posts` row gets a `comments` array built from the sub-query.
+
+Only values matching `SELECT ... ${...}` are treated as sub-queries, so ordinary
+text columns that merely begin with the word "SELECT" are left untouched.
+
 ## Index templates (mappings)
 
 By default Elasticsearch infers field types from the first document (dynamic
@@ -235,7 +261,7 @@ number at index time, so no value conversion is needed in the plugin.
 
 ## Output example
 
-It is a example when detecting insert/update/delete events.
+An example of detecting insert/update/delete events.
 
 ### sample query
 
@@ -253,7 +279,7 @@ $ mysql myweb -e "delete from search_test where text='bbb'"
 ### result
 
 `````
-$ tail -f /var/log/td-agent/td-agent.log
+$ tail -f /var/log/fluent/fluentd.log
 2013-11-25 18:22:25 +0900 replicator.myweb.search_test.insert.id: {"id":"1","text":"aaa"}
 2013-11-25 18:22:35 +0900 replicator.myweb.search_test.update.id: {"id":"1","text":"bbb"}
 2013-11-25 18:22:45 +0900 replicator.myweb.search_test.delete.id: {"id":"1"}
@@ -263,15 +289,16 @@ $ tail -f /var/log/td-agent/td-agent.log
 
 ### mysql_replicator
 
-It is easy to try it on this plugin quickly.  
-For more detail are described at [Tutorial-mysql_replicator.md](https://github.com/y-ken/fluent-plugin-mysql-replicator/blob/master/Tutorial-mysql_replicator.md)
+It is easy to try out quickly.  
+More details are described in [Tutorial-mysql_replicator.md](https://github.com/y-ken/fluent-plugin-mysql-replicator/blob/master/Tutorial-mysql_replicator.md)
 
 **Features**
 
-* Table (or view table) synchronization supported.
-* Replicate small record under a millons table.
-* It is recommend to use insert only table.
-* Nested documents are supported with placeholder which accessing to temporary table created at the each loop.
+* Synchronizes a table (or a view).
+* Best suited to small-to-medium tables (the whole result set is held in memory).
+* Insert-only tables work best.
+* Composite primary keys are supported (see *Composite primary keys* above).
+* Nested documents are supported via a `${...}` placeholder sub-query (see *Nested documents* above).
 
 **Examples**
 
@@ -280,17 +307,17 @@ For more detail are described at [Tutorial-mysql_replicator.md](https://github.c
 
 ### mysql_replicator_multi
 
-It replicates a millions of records and/or multiple tables with multiple threads.  
-This architecture is storing hash table in MySQL management table instead of ruby internal memory.  
-See tutorial at [Tutorial-mysql_replicator_multi.md](https://github.com/y-ken/fluent-plugin-mysql-replicator/blob/master/Tutorial-mysql_replicator_multi.md)
+It replicates millions of records and/or multiple tables with multiple threads.  
+This architecture stores the hash table in a MySQL management table instead of Ruby memory.  
+See the tutorial at [Tutorial-mysql_replicator_multi.md](https://github.com/y-ken/fluent-plugin-mysql-replicator/blob/master/Tutorial-mysql_replicator_multi.md)
 
 **Features**
 
-* table (or view table) synchronization supported.
-* Multiple table synchronization supported and its DSN stored in MySQL management table.
-* Using MySQL database as hash table cache to support replicate over a millions table.
-* It is recommend to make whole copy of tables.
-* Nested documents are supported with placeholder which accessing to temporary table created at the each loop.
+* Synchronizes a table (or a view).
+* Replicates multiple tables, with each source connection/query stored in a MySQL management table.
+* Uses a MySQL table as the hash-table cache, so it scales to tables with millions of rows.
+* Best suited to replicating whole tables.
+* Nested documents are supported via a `${...}` placeholder sub-query (see *Nested documents* above).
 
 **Examples**
 
@@ -310,12 +337,11 @@ http://y-ken.hatenablog.com/entry/fluent-plugin-mysql-repicator-v0.4.0
 
 ## TODO
 
-Pull requests are very welcome like below!!
+Pull requests are very welcome, for example:
 
-* more documents
-* more tests with mock.
-* support string type of primary_key.
-* support reload setting on demand.
+* more documentation and examples
+* composite primary key support for `mysql_replicator_multi`
+* reload settings on demand
 
 ## Copyright
 

--- a/Tutorial-mysql_replicator.md
+++ b/Tutorial-mysql_replicator.md
@@ -1,12 +1,15 @@
 ## Tutorial for Quickstart (mysql_replicator)
 
-It is useful for these purpose.
+Useful when you want to:
 
-* try it on this plugin quickly.
-* replicate small record under a millons table.
+* try this plugin quickly.
+* replicate a small-to-medium table.
 
-**Note:**  
-On syncing 300 million rows table, it will consume around 800MB of memory with ruby 1.9.3 environment.
+**Note:** the plugin keeps an in-memory hash of every row, so memory grows with
+the table size (on the order of ~800MB for a 300 million row table). For large
+or multiple tables, use
+[`mysql_replicator_multi`](Tutorial-mysql_replicator_multi.md), which stores the
+hash table in MySQL instead of Ruby memory.
 
 ### How it works
 
@@ -32,53 +35,56 @@ intentionally narrow the `query` to recently changed rows together with
 
 `````
 <source>
-  type mysql_replicator
+  @type mysql_replicator
 
-  # Set connection settings for replicate source.
-  host localhost
+  # Connection settings for the replication source.
+  host     localhost
   username your_mysql_user
   password your_mysql_password
   database myweb
 
-  # Set replicate query configuration.
-  query SELECT id, text from search_test;
-  primary_key id # specify unique key (default: id)
-  interval 10s  # execute query interval (default: 1m)
+  # Replication query.
+  query       SELECT id, text FROM search_test;
+  primary_key id    # a column name, or a comma-separated list for a composite key (default: id)
+  interval    10s   # how often to run the query (default: 1m)
 
-  # Enable detect deletion event not only insert/update events. (default: yes)
-  # It is useful to use `enable_delete no` that keep following recently updated record with this query.
-  # `SELECT * FROM search_test WHERE DATE_ADD(updated_at, INTERVAL 5 MINUTE) > NOW();`
+  # Detect delete events in addition to insert/update (default: yes).
+  # With `enable_delete no` you can instead narrow the query to recently updated
+  # rows, e.g.:
+  #   SELECT * FROM search_test WHERE DATE_ADD(updated_at, INTERVAL 5 MINUTE) > NOW();
   enable_delete yes
 
-  # Format output tag for each events. Placeholders usage as described below.
+  # Output tag. ${event} and ${primary_key} are expanded by the plugin.
   tag replicator.myweb.search_test.${event}.${primary_key}
-  # ${event} : the variation of row event type by insert/update/delete.
-  # ${primary_key} : the value of `replicator_manager.settings.primary_key` in manager table.
+  # ${event}       : insert / update / delete
+  # ${primary_key} : the configured primary_key column name(s)
 </source>
 
-<match replicator.*>
-  type copy
+<match replicator.**>
+  @type copy
   <store>
-    type stdout
+    @type stdout
   </store>
   <store>
-    type mysql_replicator_elasticsearch
+    @type mysql_replicator_elasticsearch
 
-    # Set Elasticsearch connection.
+    # Elasticsearch connection.
     host localhost
     port 9200
 
-    # Set Elasticsearch index, type, and unique id (primary_key) from tag.
+    # Derive the Elasticsearch index / type / id from the tag.
     tag_format (?<index_name>[^\.]+)\.(?<type_name>[^\.]+)\.(?<event>[^\.]+)\.(?<primary_key>[^\.]+)$
 
-    # Set frequency of sending bulk request to Elasticsearch node.
-    flush_interval 5s
-    
-    # Queued chunks are flushed at shutdown process. (recommend for more stability)
-    # It's sample for td-agent. If you use Yamabiko, replace path from 'td-agent' to 'yamabiko'.
-    flush_at_shutdown yes
-    buffer_type file
-    buffer_path /var/log/td-agent/buffer/mysql_replicator_elasticsearch
+    <buffer>
+      @type             file
+      path              /var/log/fluent/buffer/mysql_replicator_elasticsearch
+      flush_interval    5s
+      flush_at_shutdown true   # flush queued chunks on shutdown (recommended)
+    </buffer>
   </store>
 </match>
 `````
+
+> Using the [fluent-package](https://www.fluentd.org/download/fluent_package)
+> distribution? Its buffer/log directory is `/var/log/fluent/` (the old td-agent
+> path was `/var/log/td-agent/`).

--- a/Tutorial-mysql_replicator_multi.md
+++ b/Tutorial-mysql_replicator_multi.md
@@ -1,129 +1,96 @@
 ## Tutorial for Production (mysql_replicator_multi)
 
-It is very useful to replicate a millions of records and/or multiple tables with multiple threads.  
-This architecture is storing hash table in mysql management table instead of ruby internal memory.  
-
-**Note:**  
-On syncing 300 million rows table, it will consume around 20MB of memory with ruby 1.9.3 environment.
+Useful to replicate millions of records and/or multiple tables with multiple
+threads. This variant stores the comparison hash table in a MySQL management
+table instead of Ruby memory, so its memory footprint stays small (on the order
+of ~20MB even for a 300 million row table).
 
 ### prepare
 
-It has done with follwing two steps.
+Two steps:
 
-* create database and tables.
-* add replicator configuration.
+* create the management database and tables.
+* add a replicator configuration row.
 
-##### create database and tables.
+##### create database and tables
 
 ```
 $ mysql -umysqluser -p
 
--- For the first time, load schema.
+-- For the first time, load the schema.
 mysql> source /path/to/setup_mysql_replicator_multi.sql
 ```
 
-see [setup_mysql_replicator_multi.sql](https://github.com/y-ken/fluent-plugin-mysql-replicator/blob/master/setup_mysql_replicator_multi.sql)
-
-##### add replicator configuration.
-
-Let's download sql first.
+See [setup_mysql_replicator_multi.sql](https://github.com/y-ken/fluent-plugin-mysql-replicator/blob/master/setup_mysql_replicator_multi.sql).
+If you don't have it locally, download it first:
 
 ```
-$ wget https://raw2.github.com/y-ken/fluent-plugin-mysql-replicator/master/setup_mysql_replicator_multi.sql
+$ wget https://raw.githubusercontent.com/y-ken/fluent-plugin-mysql-replicator/master/setup_mysql_replicator_multi.sql
 ```
+
+##### add replicator configuration
 
 ```sql
--- Build 
-mysql> source /path/to/setup_mysql_replicator_multi.sql
-
--- Set working database
+-- Set the working database.
 mysql> use replicator_manager;
 
--- Add replicate source connection and query settings like below.
+-- Add a replication source connection and its query settings.
 mysql> INSERT INTO `settings`
-  (`id`, `is_active`, `name`, `host`, `port`, `username`, `password`, `database`, `query`, `prepared_query`, `interval`, `primary_key`, `enable_delete`)
+  (`is_active`, `name`, `host`, `port`, `username`, `password`, `database`,
+   `query`, `prepared_query`, `interval`, `primary_key`, `enable_delete`)
 VALUES
-  (NULL, 1, 'mydb.mytable', '192.168.100.221', 3306, 'mysqluser', 'mysqlpassword', 'mydb', 'SELECT id, text from mytable;', '', 5, 'id', 1);
+  (1, 'mydb.mytable', '192.168.100.221', 3306, 'mysqluser', 'mysqlpassword', 'mydb',
+   'SELECT id, text FROM mytable;', '', 5, 'id', 1);
 ```
 
-it is a sample which you have inserted row.
+The `settings` table also has optional columns with sensible defaults:
 
-<table>
-<thead><tr>
-<th>id</th>
-<th>is_active</th>
-<th>name</th>
-<th>host</th>
-<th>port</th>
-<th>username</th>
-<th>password</th>
-<th>database</th>
-<th>query</th>
-<th>prepared_query</th>
-<th>interval</th>
-<th>primary_key</th>
-<th>enable_delete</th>
-<th>enable_loose_insert</th>
-<th>enable_loose_delete</th>
-</tr></thead>
-<tbody><tr>
-<td>1</td>
-<td>1</td>
-<td>mydb.mytable</td>
-<td>192.168.100.221</td>
-<td>3306</td>
-<td>mysqluser</td>
-<td>mysqlpassword</td>
-<td>mydb</td>
-<td>SELECT id, text from mytable;</td>
-<td>&nbsp;</td>
-<td>5</td>
-<td>id</td>
-<td>1</td>
-<td>0</td>
-<td>0</td>
-</tr></tbody>
-</table>
+* `json_columns` — comma-separated MySQL `JSON` columns to parse into nested
+  objects (see the [README](README.md#json-column-support)).
+* `enable_retry` (default `1`) / `retry_interval` (default `30`) — keep retrying
+  when the source database is temporarily unavailable, instead of stopping.
+* `enable_loose_insert` / `enable_loose_delete` — speed/accuracy trade-offs for
+  insert/delete detection.
 
 ### configuration
 
 `````
 <source>
-  type mysql_replicator_multi
+  @type mysql_replicator_multi
 
-  # Database connection setting for manager table.
-  manager_host localhost
+  # Connection settings for the management (settings) database.
+  manager_host     localhost
   manager_username your_mysql_user
   manager_password your_mysql_password
   manager_database replicator_manager
 
-  # Format output tag for each events. Placeholders usage as described below.
+  # Output tag. ${name}, ${event} and ${primary_key} are expanded by the plugin.
   tag replicator.${name}.${event}.${primary_key}
-  # ${name} : the value of `replicator_manager.settings.name` in manager table.
-  # ${event} : the variation of row event type by insert/update/delete.
-  # ${primary_key} : the value of `replicator_manager.settings.primary_key` in manager table.
+  # ${name}        : the value of `replicator_manager.settings.name`
+  # ${event}       : insert / update / delete
+  # ${primary_key} : the value of `replicator_manager.settings.primary_key`
 </source>
 
 <match replicator.**>
-  type mysql_replicator_elasticsearch
+  @type mysql_replicator_elasticsearch
 
-  # Set Elasticsearch connection.
+  # Elasticsearch connection.
   host localhost
   port 9200
 
-  # Set Elasticsearch index, type, and unique id (primary_key) from tag.
+  # Derive the Elasticsearch index / type / id from the tag.
   tag_format (?<index_name>[^\.]+)\.(?<type_name>[^\.]+)\.(?<event>[^\.]+)\.(?<primary_key>[^\.]+)$
 
-  # Set frequency of sending bulk request to Elasticsearch node.
-  flush_interval 5s
-
-  # Set maximum retry interval (required fluentd >= 0.10.41)
-  max_retry_wait 1800
-
-  # Queued chunks are flushed at shutdown process.
-  # It's sample for td-agent. If you use Yamabiko, replace path from 'td-agent' to 'yamabiko'.
-  flush_at_shutdown yes
-  buffer_type file
-  buffer_path /var/log/td-agent/buffer/mysql_replicator_elasticsearch
+  <buffer>
+    @type              file
+    path               /var/log/fluent/buffer/mysql_replicator_elasticsearch
+    flush_interval     5s
+    flush_at_shutdown  true   # flush queued chunks on shutdown (recommended)
+    retry_max_interval 30m    # cap the exponential backoff between retries
+  </buffer>
 </match>
 `````
+
+> Using the [fluent-package](https://www.fluentd.org/download/fluent_package)
+> distribution? Its buffer/log directory is `/var/log/fluent/` (the old td-agent
+> path was `/var/log/td-agent/`).

--- a/Tutorial-mysql_replicator_multi.md
+++ b/Tutorial-mysql_replicator_multi.md
@@ -43,7 +43,14 @@ VALUES
    'SELECT id, text FROM mytable;', '', 5, 'id', 1);
 ```
 
-The `settings` table also has optional columns with sensible defaults:
+The inserted row then looks like this — the columns you didn't set fall back to
+their defaults:
+
+| id | is_active | name | host | port | username | password | database | query | prepared_query | interval | primary_key | json_columns | enable_delete | enable_loose_insert | enable_loose_delete | enable_retry | retry_interval |
+|----|-----------|------|------|------|----------|----------|----------|-------|----------------|----------|-------------|--------------|---------------|---------------------|---------------------|--------------|----------------|
+| 1 | 1 | mydb.mytable | 192.168.100.221 | 3306 | mysqluser | mysqlpassword | mydb | SELECT id, text FROM mytable; |  | 5 | id | NULL | 1 | 0 | 0 | 1 | 30 |
+
+The optional columns have sensible defaults:
 
 * `json_columns` — comma-separated MySQL `JSON` columns to parse into nested
   objects (see the [README](README.md#json-column-support)).

--- a/fluent-plugin-mysql-replicator.gemspec
+++ b/fluent-plugin-mysql-replicator.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Kentaro Yoshida"]
   s.email       = ["y.ken.studio@gmail.com"]
   s.homepage    = "https://github.com/y-ken/fluent-plugin-mysql-replicator"
-  s.summary     = %q{Fluentd input plugin to track insert/update/delete event from MySQL database server. Not only that, it could multiple table replication and generate nested document for Elasticsearch/Solr. It's comming support replicate to another RDB/noSQL.}
+  s.summary     = %q{Fluentd input plugin that tracks insert/update/delete events on a MySQL database and replicates one or many tables into Elasticsearch or Solr, with support for nested documents.}
   s.license     = "Apache-2.0"
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
## Summary

Docs-only refresh of `README.md`, `Tutorial-mysql_replicator.md`, and
`Tutorial-mysql_replicator_multi.md`. They had drifted to Fluentd v0.12 / td-agent
era content.

## Stale → fixed

**Wrong / broken**
- Tutorials used Fluentd **v0.12 syntax** (`type`, `buffer_type`/`buffer_path`)
  → updated to v1 (`@type`, `<buffer>` section).
- `Tutorial-mysql_replicator_multi.md` linked a **dead `raw2.github.com` URL**
  → `raw.githubusercontent.com`.
- Single-plugin tutorial used `<match replicator.*>`, which **cannot match the
  multi-level tag** `replicator.myweb.search_test...` → `replicator.**`.
- Single-plugin tutorial's `${primary_key}` comment wrongly pointed at the
  **manager table** (that's the multi plugin) → corrected.
- Installation pinned `-v 1.0.3` and referenced **EOL td-agent2/td-agent3**
  → RubyGems + `fluent-gem` (fluent-package).
- Requirements table claimed Fluentd v0.14 / Ruby 2.1 as current → now reflects
  the **tested Ruby 3.2–4.0 / Fluentd 1.x / fluent-package v6 LTS / ES 6–9**.

**Missing docs**
- Documented the **nested-document (`${...}` sub-query)** feature (only a vague
  one-liner before; also reflects the #4/#52 `${...}`-required behavior).
- Cross-referenced composite primary keys, `json_columns`, and
  `enable_retry`/`retry_interval` in the multi tutorial.

**Cosmetic**
- Typos: `comming`, `millons`, `follwing`, "It is a example", and grammar.
- Dev-container `bundle install --path` (deprecated) → `bundle config set
  --local path vendor/bundle && bundle install`.
- Output example log path `/var/log/td-agent/` → `/var/log/fluent/`.
- Removed the completed "support string type of primary_key" TODO.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)